### PR TITLE
Prevented github forks from sendling travis alerts to IRC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,13 @@ script:
 after_script:
   - $HOME/gopath/bin/goveralls -coverprofile=coverage.report -service=travis-ci
 
-# currently cannot customise per user fork, see:
+# encrpyt channel name to get around issue
 # https://github.com/travis-ci/travis-ci/issues/1094
 notifications:
   irc:
     channels:
-      - "irc.mozilla.org#taskcluster-bots"
+      # encrpyted string was "irc.mozilla.org#taskcluster-bots"
+      - secure: "EcOYIepqv18ohTPA3rMkHyUCcKzwSGoSrmJoWYksWJYuwbnIMqYsLbgqY8AOkxD/okPMbj3mBAArAo4mRutGWrsCQQrBBK9hxIhj3abdBf6120EjUSWOTdIFIkmSepQeat6/8KJONkSwyCBjnjPs3bhSH1hYY1qsRrHo8g2OUJI="
     on_success: always
     on_failure: always
     template:


### PR DESCRIPTION
Fix for https://github.com/travis-ci/travis-ci/issues/1094.

Forks will no longer send travis irc notifications to IRC channel :+1: 

Big thanks to @rail!
