### PR TITLE
Mock package

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -73,7 +73,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/auth/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package auth
 
@@ -118,21 +118,21 @@ func New(credentials *tcclient.Credentials) *Auth {
 // it is a prefix of the clientId are returned.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#listClients
-func (myAuth *Auth) ListClients(prefix string) (*ListClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) ListClients(prefix string) (*ListClientResponse, error) {
 	v := url.Values{}
 	v.Add("prefix", prefix)
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/clients/", new(ListClientResponse), v)
-	return responseObject.(*ListClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/", new(ListClientResponse), v)
+	return responseObject.(*ListClientResponse), err
 }
 
 // Get information about a single client.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#client
-func (myAuth *Auth) Client(clientId string) (*GetClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) Client(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
-	return responseObject.(*GetClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
+	return responseObject.(*GetClientResponse), err
 }
 
 // Create a new client and get the `accessToken` for this client.
@@ -152,10 +152,10 @@ func (myAuth *Auth) Client(clientId string) (*GetClientResponse, *tcclient.CallS
 //   * auth:create-client:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#createClient
-func (myAuth *Auth) CreateClient(clientId string, payload *CreateClientRequest) (*CreateClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) CreateClient(clientId string, payload *CreateClientRequest) (*CreateClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/clients/"+url.QueryEscape(clientId), new(CreateClientResponse), nil)
-	return responseObject.(*CreateClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/clients/"+url.QueryEscape(clientId), new(CreateClientResponse), nil)
+	return responseObject.(*CreateClientResponse), err
 }
 
 // Reset a clients `accessToken`, this will revoke the existing
@@ -169,10 +169,10 @@ func (myAuth *Auth) CreateClient(clientId string, payload *CreateClientRequest) 
 //   * auth:reset-access-token:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#resetAccessToken
-func (myAuth *Auth) ResetAccessToken(clientId string) (*CreateClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) ResetAccessToken(clientId string) (*CreateClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/reset", new(CreateClientResponse), nil)
-	return responseObject.(*CreateClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/reset", new(CreateClientResponse), nil)
+	return responseObject.(*CreateClientResponse), err
 }
 
 // Update an exisiting client. The `clientId` and `accessToken` cannot be
@@ -185,10 +185,10 @@ func (myAuth *Auth) ResetAccessToken(clientId string) (*CreateClientResponse, *t
 //   * auth:update-client:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#updateClient
-func (myAuth *Auth) UpdateClient(clientId string, payload *CreateClientRequest) (*GetClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) UpdateClient(clientId string, payload *CreateClientRequest) (*GetClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
-	return responseObject.(*GetClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/clients/"+url.QueryEscape(clientId), new(GetClientResponse), nil)
+	return responseObject.(*GetClientResponse), err
 }
 
 // Enable a client that was disabled with `disableClient`.  If the client
@@ -201,10 +201,10 @@ func (myAuth *Auth) UpdateClient(clientId string, payload *CreateClientRequest) 
 //   * auth:enable-client:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#enableClient
-func (myAuth *Auth) EnableClient(clientId string) (*GetClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) EnableClient(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/enable", new(GetClientResponse), nil)
-	return responseObject.(*GetClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/enable", new(GetClientResponse), nil)
+	return responseObject.(*GetClientResponse), err
 }
 
 // Disable a client.  If the client is already disabled, this does nothing.
@@ -216,10 +216,10 @@ func (myAuth *Auth) EnableClient(clientId string) (*GetClientResponse, *tcclient
 //   * auth:disable-client:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#disableClient
-func (myAuth *Auth) DisableClient(clientId string) (*GetClientResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) DisableClient(clientId string) (*GetClientResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/disable", new(GetClientResponse), nil)
-	return responseObject.(*GetClientResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/clients/"+url.QueryEscape(clientId)+"/disable", new(GetClientResponse), nil)
+	return responseObject.(*GetClientResponse), err
 }
 
 // Delete a client, please note that any roles related to this client must
@@ -229,30 +229,30 @@ func (myAuth *Auth) DisableClient(clientId string) (*GetClientResponse, *tcclien
 //   * auth:delete-client:<clientId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#deleteClient
-func (myAuth *Auth) DeleteClient(clientId string) (*tcclient.CallSummary, error) {
+func (myAuth *Auth) DeleteClient(clientId string) error {
 	cd := tcclient.ConnectionData(*myAuth)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/clients/"+url.QueryEscape(clientId), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/clients/"+url.QueryEscape(clientId), nil, nil)
+	return err
 }
 
 // Get a list of all roles, each role object also includes the list of
 // scopes it expands to.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#listRoles
-func (myAuth *Auth) ListRoles() (*ListRolesResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) ListRoles() (*ListRolesResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/roles/", new(ListRolesResponse), nil)
-	return responseObject.(*ListRolesResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/roles/", new(ListRolesResponse), nil)
+	return responseObject.(*ListRolesResponse), err
 }
 
 // Get information about a single role, including the set of scopes that the
 // role expands to.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#role
-func (myAuth *Auth) Role(roleId string) (*GetRoleResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) Role(roleId string) (*GetRoleResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
-	return responseObject.(*GetRoleResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	return responseObject.(*GetRoleResponse), err
 }
 
 // Create a new role.
@@ -266,10 +266,10 @@ func (myAuth *Auth) Role(roleId string) (*GetRoleResponse, *tcclient.CallSummary
 //   * auth:create-role:<roleId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#createRole
-func (myAuth *Auth) CreateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) CreateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
-	return responseObject.(*GetRoleResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	return responseObject.(*GetRoleResponse), err
 }
 
 // Update an existing role.
@@ -281,10 +281,10 @@ func (myAuth *Auth) CreateRole(roleId string, payload *CreateRoleRequest) (*GetR
 //   * auth:update-role:<roleId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#updateRole
-func (myAuth *Auth) UpdateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) UpdateRole(roleId string, payload *CreateRoleRequest) (*GetRoleResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
-	return responseObject.(*GetRoleResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/roles/"+url.QueryEscape(roleId), new(GetRoleResponse), nil)
+	return responseObject.(*GetRoleResponse), err
 }
 
 // Delete a role. This operation will succeed regardless of whether or not
@@ -294,20 +294,20 @@ func (myAuth *Auth) UpdateRole(roleId string, payload *CreateRoleRequest) (*GetR
 //   * auth:delete-role:<roleId>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#deleteRole
-func (myAuth *Auth) DeleteRole(roleId string) (*tcclient.CallSummary, error) {
+func (myAuth *Auth) DeleteRole(roleId string) error {
 	cd := tcclient.ConnectionData(*myAuth)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/roles/"+url.QueryEscape(roleId), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/roles/"+url.QueryEscape(roleId), nil, nil)
+	return err
 }
 
 // Return an expanded copy of the given scopeset, with scopes implied by any
 // roles included.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#expandScopes
-func (myAuth *Auth) ExpandScopes(payload *SetOfScopes) (*SetOfScopes, *tcclient.CallSummary, error) {
+func (myAuth *Auth) ExpandScopes(payload *SetOfScopes) (*SetOfScopes, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "GET", "/scopes/expand", new(SetOfScopes), nil)
-	return responseObject.(*SetOfScopes), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "GET", "/scopes/expand", new(SetOfScopes), nil)
+	return responseObject.(*SetOfScopes), err
 }
 
 // Return the expanded scopes available in the request, taking into account all sources
@@ -315,10 +315,10 @@ func (myAuth *Auth) ExpandScopes(payload *SetOfScopes) (*SetOfScopes, *tcclient.
 // and roles).
 //
 // See http://docs.taskcluster.net/auth/api-docs/#currentScopes
-func (myAuth *Auth) CurrentScopes() (*SetOfScopes, *tcclient.CallSummary, error) {
+func (myAuth *Auth) CurrentScopes() (*SetOfScopes, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/scopes/current", new(SetOfScopes), nil)
-	return responseObject.(*SetOfScopes), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/scopes/current", new(SetOfScopes), nil)
+	return responseObject.(*SetOfScopes), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -347,10 +347,10 @@ func (myAuth *Auth) CurrentScopes() (*SetOfScopes, *tcclient.CallSummary, error)
 //   * auth:aws-s3:<level>:<bucket>/<prefix>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#awsS3Credentials
-func (myAuth *Auth) AwsS3Credentials(level, bucket, prefix string) (*AWSS3CredentialsResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) AwsS3Credentials(level, bucket, prefix string) (*AWSS3CredentialsResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/aws/s3/"+url.QueryEscape(level)+"/"+url.QueryEscape(bucket)+"/"+url.QueryEscape(prefix), new(AWSS3CredentialsResponse), nil)
-	return responseObject.(*AWSS3CredentialsResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/aws/s3/"+url.QueryEscape(level)+"/"+url.QueryEscape(bucket)+"/"+url.QueryEscape(prefix), new(AWSS3CredentialsResponse), nil)
+	return responseObject.(*AWSS3CredentialsResponse), err
 }
 
 // Returns a signed URL for AwsS3Credentials, valid for the specified duration.
@@ -372,10 +372,10 @@ func (myAuth *Auth) AwsS3Credentials_SignedURL(level, bucket, prefix string, dur
 //   * auth:azure-table-access:<account>/<table>
 //
 // See http://docs.taskcluster.net/auth/api-docs/#azureTableSAS
-func (myAuth *Auth) AzureTableSAS(account, table string) (*AzureSharedAccessSignatureResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) AzureTableSAS(account, table string) (*AzureSharedAccessSignatureResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/table/"+url.QueryEscape(table)+"/read-write", new(AzureSharedAccessSignatureResponse), nil)
-	return responseObject.(*AzureSharedAccessSignatureResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/azure/"+url.QueryEscape(account)+"/table/"+url.QueryEscape(table)+"/read-write", new(AzureSharedAccessSignatureResponse), nil)
+	return responseObject.(*AzureSharedAccessSignatureResponse), err
 }
 
 // Returns a signed URL for AzureTableSAS, valid for the specified duration.
@@ -397,10 +397,10 @@ func (myAuth *Auth) AzureTableSAS_SignedURL(account, table string, duration time
 // the secret credentials leave this service.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#authenticateHawk
-func (myAuth *Auth) AuthenticateHawk(payload *HawkSignatureAuthenticationRequest) (*HawkSignatureAuthenticationResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) AuthenticateHawk(payload *HawkSignatureAuthenticationRequest) (*HawkSignatureAuthenticationResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/authenticate-hawk", new(HawkSignatureAuthenticationResponse), nil)
-	return responseObject.(*HawkSignatureAuthenticationResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/authenticate-hawk", new(HawkSignatureAuthenticationResponse), nil)
+	return responseObject.(*HawkSignatureAuthenticationResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -418,10 +418,10 @@ func (myAuth *Auth) AuthenticateHawk(payload *HawkSignatureAuthenticationRequest
 // and scopes as seen by the API method.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#testAuthenticate
-func (myAuth *Auth) TestAuthenticate(payload *TestAuthenticateRequest) (*TestAuthenticateResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) TestAuthenticate(payload *TestAuthenticateRequest) (*TestAuthenticateResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/test-authenticate", new(TestAuthenticateResponse), nil)
-	return responseObject.(*TestAuthenticateResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/test-authenticate", new(TestAuthenticateResponse), nil)
+	return responseObject.(*TestAuthenticateResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -443,10 +443,10 @@ func (myAuth *Auth) TestAuthenticate(payload *TestAuthenticateRequest) (*TestAut
 // required scopes via query arguments.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#testAuthenticateGet
-func (myAuth *Auth) TestAuthenticateGet() (*TestAuthenticateResponse, *tcclient.CallSummary, error) {
+func (myAuth *Auth) TestAuthenticateGet() (*TestAuthenticateResponse, error) {
 	cd := tcclient.ConnectionData(*myAuth)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/test-authenticate-get/", new(TestAuthenticateResponse), nil)
-	return responseObject.(*TestAuthenticateResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/test-authenticate-get/", new(TestAuthenticateResponse), nil)
+	return responseObject.(*TestAuthenticateResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -456,8 +456,8 @@ func (myAuth *Auth) TestAuthenticateGet() (*TestAuthenticateResponse, *tcclient.
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/auth/api-docs/#ping
-func (myAuth *Auth) Ping() (*tcclient.CallSummary, error) {
+func (myAuth *Auth) Ping() error {
 	cd := tcclient.ConnectionData(*myAuth)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -73,7 +73,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/auth/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package auth
 
@@ -85,6 +85,32 @@ import (
 )
 
 type Auth tcclient.ConnectionData
+
+// The AbstractAuth interface specifies the methods provided
+// by Auth this is useful for mocking instances in tests.
+type AbstractAuth interface {
+	ListClients(prefix string) (*ListClientResponse, error)
+	Client(clientId string) (*GetClientResponse, error)
+	CreateClient(clientId string) (*CreateClientResponse, error)
+	ResetAccessToken(clientId string) (*CreateClientResponse, error)
+	UpdateClient(clientId string) (*GetClientResponse, error)
+	EnableClient(clientId string) (*GetClientResponse, error)
+	DisableClient(clientId string) (*GetClientResponse, error)
+	DeleteClient(clientId string) error
+	ListRoles() (*ListRolesResponse, error)
+	Role(roleId string) (*GetRoleResponse, error)
+	CreateRole(roleId string) (*GetRoleResponse, error)
+	UpdateRole(roleId string) (*GetRoleResponse, error)
+	DeleteRole(roleId string) error
+	ExpandScopes() (*SetOfScopes, error)
+	CurrentScopes() (*SetOfScopes, error)
+	AwsS3Credentials(level, bucket, prefix string) (*AWSS3CredentialsResponse, error)
+	AzureTableSAS(account, table string) (*AzureSharedAccessSignatureResponse, error)
+	AuthenticateHawk() (*HawkSignatureAuthenticationResponse, error)
+	TestAuthenticate() (*TestAuthenticateResponse, error)
+	TestAuthenticateGet() (*TestAuthenticateResponse, error)
+	Ping() error
+}
 
 // Returns a pointer to Auth, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/auth/auth_examples_test.go
+++ b/auth/auth_examples_test.go
@@ -24,7 +24,7 @@ func Example_scopes() {
 	)
 
 	// Look up client details for client id "project/taskcluster/tc-client-go/tests"...
-	resp, _, err := myAuth.Client("project/taskcluster/tc-client-go/tests")
+	resp, err := myAuth.Client("project/taskcluster/tc-client-go/tests")
 
 	// Handle any errors...
 	if err != nil {
@@ -57,7 +57,7 @@ func Example_updateClient() {
 	myAuth.BaseURL = "http://localhost:60024/v1"
 
 	// Update client id "b2g-power-tests" with new description and expiry...
-	client, cs, err := myAuth.UpdateClient(
+	client, err := myAuth.UpdateClient(
 		"b2g-power-tests",
 		&auth.CreateClientRequest{
 			Description: "Grant access to download artifacts for `flame-kk-eng`",
@@ -80,7 +80,4 @@ func Example_updateClient() {
 	fmt.Printf("Last Date Used:   %v\n", client.LastDateUsed)
 	fmt.Printf("Last Modified:    %v\n", client.LastModified)
 	fmt.Printf("Last Rotated:     %v\n", client.LastRotated)
-
-	// if we want, we can also show the raw json that was returned...
-	fmt.Println(cs.HttpResponseBody)
 }

--- a/awsprovisioner/awsprovisioner.go
+++ b/awsprovisioner/awsprovisioner.go
@@ -56,7 +56,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/aws-provisioner/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package awsprovisioner
 
@@ -68,6 +68,26 @@ import (
 )
 
 type AwsProvisioner tcclient.ConnectionData
+
+// The AbstractAwsProvisioner interface specifies the methods provided
+// by AwsProvisioner this is useful for mocking instances in tests.
+type AbstractAwsProvisioner interface {
+	CreateWorkerType(workerType string) (*GetWorkerTypeRequest, error)
+	UpdateWorkerType(workerType string) (*GetWorkerTypeRequest, error)
+	WorkerType(workerType string) (*GetWorkerTypeRequest, error)
+	RemoveWorkerType(workerType string) error
+	ListWorkerTypes() (*ListWorkerTypes, error)
+	CreateSecret(token string) error
+	GetSecret(token string) (*GetSecretResponse, error)
+	InstanceStarted(instanceId, token string) error
+	RemoveSecret(token string) error
+	GetLaunchSpecs(workerType string) (*GetAllLaunchSpecsResponse, error)
+	AwsState() error
+	State(workerType string) error
+	Ping() error
+	BackendStatus() error
+	APIReference() error
+}
 
 // Returns a pointer to AwsProvisioner, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/awsprovisioner/awsprovisioner.go
+++ b/awsprovisioner/awsprovisioner.go
@@ -56,7 +56,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/aws-provisioner/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package awsprovisioner
 
@@ -127,10 +127,10 @@ func New(credentials *tcclient.Credentials) *AwsProvisioner {
 //   * aws-provisioner:manage-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#createWorkerType
-func (awsProvisioner *AwsProvisioner) CreateWorkerType(workerType string, payload *CreateWorkerTypeRequest) (*GetWorkerTypeRequest, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) CreateWorkerType(workerType string, payload *CreateWorkerTypeRequest) (*GetWorkerTypeRequest, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/worker-type/"+url.QueryEscape(workerType), new(GetWorkerTypeRequest), nil)
-	return responseObject.(*GetWorkerTypeRequest), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/worker-type/"+url.QueryEscape(workerType), new(GetWorkerTypeRequest), nil)
+	return responseObject.(*GetWorkerTypeRequest), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -151,10 +151,10 @@ func (awsProvisioner *AwsProvisioner) CreateWorkerType(workerType string, payloa
 //   * aws-provisioner:manage-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#updateWorkerType
-func (awsProvisioner *AwsProvisioner) UpdateWorkerType(workerType string, payload *CreateWorkerTypeRequest) (*GetWorkerTypeRequest, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) UpdateWorkerType(workerType string, payload *CreateWorkerTypeRequest) (*GetWorkerTypeRequest, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/worker-type/"+url.QueryEscape(workerType)+"/update", new(GetWorkerTypeRequest), nil)
-	return responseObject.(*GetWorkerTypeRequest), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/worker-type/"+url.QueryEscape(workerType)+"/update", new(GetWorkerTypeRequest), nil)
+	return responseObject.(*GetWorkerTypeRequest), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -170,10 +170,10 @@ func (awsProvisioner *AwsProvisioner) UpdateWorkerType(workerType string, payloa
 //   * aws-provisioner:manage-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#workerType
-func (awsProvisioner *AwsProvisioner) WorkerType(workerType string) (*GetWorkerTypeRequest, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) WorkerType(workerType string) (*GetWorkerTypeRequest, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/worker-type/"+url.QueryEscape(workerType), new(GetWorkerTypeRequest), nil)
-	return responseObject.(*GetWorkerTypeRequest), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-type/"+url.QueryEscape(workerType), new(GetWorkerTypeRequest), nil)
+	return responseObject.(*GetWorkerTypeRequest), err
 }
 
 // Returns a signed URL for WorkerType, valid for the specified duration.
@@ -205,10 +205,10 @@ func (awsProvisioner *AwsProvisioner) WorkerType_SignedURL(workerType string, du
 //   * aws-provisioner:manage-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#removeWorkerType
-func (awsProvisioner *AwsProvisioner) RemoveWorkerType(workerType string) (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) RemoveWorkerType(workerType string) error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/worker-type/"+url.QueryEscape(workerType), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/worker-type/"+url.QueryEscape(workerType), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -219,10 +219,10 @@ func (awsProvisioner *AwsProvisioner) RemoveWorkerType(workerType string) (*tccl
 // type definition but are still running in AWS.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#listWorkerTypes
-func (awsProvisioner *AwsProvisioner) ListWorkerTypes() (*ListWorkerTypes, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) ListWorkerTypes() (*ListWorkerTypes, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/list-worker-types", new(ListWorkerTypes), nil)
-	return responseObject.(*ListWorkerTypes), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/list-worker-types", new(ListWorkerTypes), nil)
+	return responseObject.(*ListWorkerTypes), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -238,10 +238,10 @@ func (awsProvisioner *AwsProvisioner) ListWorkerTypes() (*ListWorkerTypes, *tccl
 //   * aws-provisioner:create-secret
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#createSecret
-func (awsProvisioner *AwsProvisioner) CreateSecret(token string, payload *GetSecretRequest) (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) CreateSecret(token string, payload *GetSecretRequest) error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(payload, "PUT", "/secret/"+url.QueryEscape(token), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(payload, "PUT", "/secret/"+url.QueryEscape(token), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -255,10 +255,10 @@ func (awsProvisioner *AwsProvisioner) CreateSecret(token string, payload *GetSec
 // user data associated with the instance.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#getSecret
-func (awsProvisioner *AwsProvisioner) GetSecret(token string) (*GetSecretResponse, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) GetSecret(token string) (*GetSecretResponse, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/secret/"+url.QueryEscape(token), new(GetSecretResponse), nil)
-	return responseObject.(*GetSecretResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/secret/"+url.QueryEscape(token), new(GetSecretResponse), nil)
+	return responseObject.(*GetSecretResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -270,10 +270,10 @@ func (awsProvisioner *AwsProvisioner) GetSecret(token string) (*GetSecretRespons
 // but that seems like overkill
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#instanceStarted
-func (awsProvisioner *AwsProvisioner) InstanceStarted(instanceId, token string) (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) InstanceStarted(instanceId, token string) error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/instance-started/"+url.QueryEscape(instanceId)+"/"+url.QueryEscape(token), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/instance-started/"+url.QueryEscape(instanceId)+"/"+url.QueryEscape(token), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -286,10 +286,10 @@ func (awsProvisioner *AwsProvisioner) InstanceStarted(instanceId, token string) 
 // to untrusted processes to prevent credential and/or secret leakage.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#removeSecret
-func (awsProvisioner *AwsProvisioner) RemoveSecret(token string) (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) RemoveSecret(token string) error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.QueryEscape(token), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.QueryEscape(token), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -305,10 +305,10 @@ func (awsProvisioner *AwsProvisioner) RemoveSecret(token string) (*tcclient.Call
 //   * aws-provisioner:manage-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#getLaunchSpecs
-func (awsProvisioner *AwsProvisioner) GetLaunchSpecs(workerType string) (*GetAllLaunchSpecsResponse, *tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) GetLaunchSpecs(workerType string) (*GetAllLaunchSpecsResponse, error) {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/worker-type/"+url.QueryEscape(workerType)+"/launch-specifications", new(GetAllLaunchSpecsResponse), nil)
-	return responseObject.(*GetAllLaunchSpecsResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/worker-type/"+url.QueryEscape(workerType)+"/launch-specifications", new(GetAllLaunchSpecsResponse), nil)
+	return responseObject.(*GetAllLaunchSpecsResponse), err
 }
 
 // Returns a signed URL for GetLaunchSpecs, valid for the specified duration.
@@ -334,10 +334,10 @@ func (awsProvisioner *AwsProvisioner) GetLaunchSpecs_SignedURL(workerType string
 //   * aws-provisioner:aws-state
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#awsState
-func (awsProvisioner *AwsProvisioner) AwsState() (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) AwsState() error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/aws-state", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/aws-state", nil, nil)
+	return err
 }
 
 // Returns a signed URL for AwsState, valid for the specified duration.
@@ -362,10 +362,10 @@ func (awsProvisioner *AwsProvisioner) AwsState_SignedURL(duration time.Duration)
 //   * aws-provisioner:view-worker-type:<workerType>
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#state
-func (awsProvisioner *AwsProvisioner) State(workerType string) (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) State(workerType string) error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/state/"+url.QueryEscape(workerType), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/state/"+url.QueryEscape(workerType), nil, nil)
+	return err
 }
 
 // Returns a signed URL for State, valid for the specified duration.
@@ -386,10 +386,10 @@ func (awsProvisioner *AwsProvisioner) State_SignedURL(workerType string, duratio
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#ping
-func (awsProvisioner *AwsProvisioner) Ping() (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) Ping() error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -397,10 +397,10 @@ func (awsProvisioner *AwsProvisioner) Ping() (*tcclient.CallSummary, error) {
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#backendStatus
-func (awsProvisioner *AwsProvisioner) BackendStatus() (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) BackendStatus() error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/backend-status", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/backend-status", nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -410,8 +410,8 @@ func (awsProvisioner *AwsProvisioner) BackendStatus() (*tcclient.CallSummary, er
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/aws-provisioner/api-docs/#apiReference
-func (awsProvisioner *AwsProvisioner) APIReference() (*tcclient.CallSummary, error) {
+func (awsProvisioner *AwsProvisioner) APIReference() error {
 	cd := tcclient.ConnectionData(*awsProvisioner)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/api-reference", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/api-reference", nil, nil)
+	return err
 }

--- a/codegenerator/model-data.txt
+++ b/codegenerator/model-data.txt
@@ -1,4 +1,4 @@
-Generated: 1458241918
+Generated: 1458677496
 The following file is an auto-generated static dump of the API models at time of code generation.
 It is provided here for reference purposes, but is not used by any code.
 

--- a/codegenerator/model-data.txt
+++ b/codegenerator/model-data.txt
@@ -1,4 +1,4 @@
-Generated: 1457021704
+Generated: 1458241918
 The following file is an auto-generated static dump of the API models at time of code generation.
 It is provided here for reference purposes, but is not used by any code.
 

--- a/codegenerator/model/api.go
+++ b/codegenerator/model/api.go
@@ -267,9 +267,9 @@ func (entry *APIEntry) generateDirectMethod(apiName string) string {
 		}
 	}
 
-	responseType := "(*tcclient.CallSummary, error)"
+	responseType := "(error)"
 	if entry.Output != "" {
-		responseType = "(*" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + ", *tcclient.CallSummary, error)"
+		responseType = "(*" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + ", error)"
 	}
 
 	content := comment
@@ -277,11 +277,11 @@ func (entry *APIEntry) generateDirectMethod(apiName string) string {
 	content += queryCode
 	content += "\tcd := tcclient.ConnectionData(*" + entry.Parent.apiDef.ExampleVarName + ")\n"
 	if entry.Output != "" {
-		content += "\tresponseObject, callSummary, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + url.QueryEscape(", -1), ">", ") + \"", -1) + "\", new(" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + "), " + queryExpr + ")\n"
-		content += "\treturn responseObject.(*" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + "), callSummary, err\n"
+		content += "\tresponseObject, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + url.QueryEscape(", -1), ">", ") + \"", -1) + "\", new(" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + "), " + queryExpr + ")\n"
+		content += "\treturn responseObject.(*" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + "), err\n"
 	} else {
-		content += "\t_, callSummary, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + url.QueryEscape(", -1), ">", ") + \"", -1) + "\", nil, " + queryExpr + ")\n"
-		content += "\treturn callSummary, err\n"
+		content += "\t_, _, err := (&cd).APICall(" + apiArgsPayload + ", \"" + strings.ToUpper(entry.Method) + "\", \"" + strings.Replace(strings.Replace(entry.Route, "<", "\" + url.QueryEscape(", -1), ">", ") + \"", -1) + "\", nil, " + queryExpr + ")\n"
+		content += "\treturn err\n"
 	}
 	content += "}\n"
 	content += "\n"

--- a/codegenerator/model/api.go
+++ b/codegenerator/model/api.go
@@ -118,6 +118,15 @@ import (
 
 type ` + api.apiDef.Name + ` tcclient.ConnectionData
 
+// The Abstract` + api.apiDef.Name + ` interface specifies the methods provided
+// by ` + api.apiDef.Name + ` this is useful for mocking instances in tests.
+type Abstract` + api.apiDef.Name + ` interface {`
+	for _, entry := range api.Entries {
+		content += "\n" + entry.signature()
+	}
+	content += `
+}
+
 // Returns a pointer to ` + api.apiDef.Name + `, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred
 // url. Authentication can be disabled (for example if you wish to use the
@@ -174,6 +183,17 @@ type APIEntry struct {
 
 	MethodName string
 	Parent     *API
+}
+
+func (entry *APIEntry) signature() string {
+	inputParams, _, _ := entry.getInputParamsAndQueryStringCode()
+
+	responseType := "(error)"
+	if entry.Output != "" {
+		responseType = "(*" + entry.Parent.apiDef.schemas.SubSchema(entry.Output).TypeName + ", error)"
+	}
+
+	return entry.MethodName + "(" + inputParams + ") " + responseType
 }
 
 // Add entry.Input and entry.Output to schemaURLs, if they are set

--- a/github/github.go
+++ b/github/github.go
@@ -35,7 +35,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/github/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package github
 
@@ -80,10 +80,10 @@ func New(credentials *tcclient.Credentials) *Github {
 //   *
 //
 // See http://docs.taskcluster.net/services/taskcluster-github/#githubWebHookConsumer
-func (myGithub *Github) GithubWebHookConsumer() (*tcclient.CallSummary, error) {
+func (myGithub *Github) GithubWebHookConsumer() error {
 	cd := tcclient.ConnectionData(*myGithub)
-	_, callSummary, err := (&cd).APICall(nil, "POST", "/github", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "POST", "/github", nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -93,8 +93,8 @@ func (myGithub *Github) GithubWebHookConsumer() (*tcclient.CallSummary, error) {
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/services/taskcluster-github/#ping
-func (myGithub *Github) Ping() (*tcclient.CallSummary, error) {
+func (myGithub *Github) Ping() error {
 	cd := tcclient.ConnectionData(*myGithub)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/github/github.go
+++ b/github/github.go
@@ -35,13 +35,20 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/github/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package github
 
 import "github.com/taskcluster/taskcluster-client-go/tcclient"
 
 type Github tcclient.ConnectionData
+
+// The AbstractGithub interface specifies the methods provided
+// by Github this is useful for mocking instances in tests.
+type AbstractGithub interface {
+	GithubWebHookConsumer() error
+	Ping() error
+}
 
 // Returns a pointer to Github, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -43,7 +43,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/hooks/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package hooks
 
@@ -54,6 +54,19 @@ import (
 )
 
 type Hooks tcclient.ConnectionData
+
+// The AbstractHooks interface specifies the methods provided
+// by Hooks this is useful for mocking instances in tests.
+type AbstractHooks interface {
+	ListHookGroups() (*HookGroups, error)
+	ListHooks(hookGroupId string) (*HookList, error)
+	Hook(hookGroupId, hookId string) (*HookDefinition, error)
+	GetHookStatus(hookGroupId, hookId string) (*HookStatusResponse, error)
+	GetHookSchedule(hookGroupId, hookId string) (*HookScheduleResponse, error)
+	CreateHook(hookGroupId, hookId string) (*HookDefinition, error)
+	UpdateHook(hookGroupId, hookId string) (*HookDefinition, error)
+	RemoveHook(hookGroupId, hookId string) error
+}
 
 // Returns a pointer to Hooks, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -43,7 +43,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/hooks/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package hooks
 
@@ -88,10 +88,10 @@ func New(credentials *tcclient.Credentials) *Hooks {
 // This endpoint will return a list of all hook groups with at least one hook.
 //
 // See http://docs.taskcluster.net/services/hooks/#listHookGroups
-func (myHooks *Hooks) ListHookGroups() (*HookGroups, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) ListHookGroups() (*HookGroups, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/hooks", new(HookGroups), nil)
-	return responseObject.(*HookGroups), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks", new(HookGroups), nil)
+	return responseObject.(*HookGroups), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -100,10 +100,10 @@ func (myHooks *Hooks) ListHookGroups() (*HookGroups, *tcclient.CallSummary, erro
 // given hook group.
 //
 // See http://docs.taskcluster.net/services/hooks/#listHooks
-func (myHooks *Hooks) ListHooks(hookGroupId string) (*HookList, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) ListHooks(hookGroupId string) (*HookList, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId), new(HookList), nil)
-	return responseObject.(*HookList), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId), new(HookList), nil)
+	return responseObject.(*HookList), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -112,10 +112,10 @@ func (myHooks *Hooks) ListHooks(hookGroupId string) (*HookList, *tcclient.CallSu
 // and hookId.
 //
 // See http://docs.taskcluster.net/services/hooks/#hook
-func (myHooks *Hooks) Hook(hookGroupId, hookId string) (*HookDefinition, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) Hook(hookGroupId, hookId string) (*HookDefinition, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
-	return responseObject.(*HookDefinition), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	return responseObject.(*HookDefinition), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -124,10 +124,10 @@ func (myHooks *Hooks) Hook(hookGroupId, hookId string) (*HookDefinition, *tcclie
 // snapshot in time and may vary from one call to the next.
 //
 // See http://docs.taskcluster.net/services/hooks/#getHookStatus
-func (myHooks *Hooks) GetHookStatus(hookGroupId, hookId string) (*HookStatusResponse, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) GetHookStatus(hookGroupId, hookId string) (*HookStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/status", new(HookStatusResponse), nil)
-	return responseObject.(*HookStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/status", new(HookStatusResponse), nil)
+	return responseObject.(*HookStatusResponse), err
 }
 
 // Stability: *** DEPRECATED ***
@@ -136,10 +136,10 @@ func (myHooks *Hooks) GetHookStatus(hookGroupId, hookId string) (*HookStatusResp
 // for the given hook.
 //
 // See http://docs.taskcluster.net/services/hooks/#getHookSchedule
-func (myHooks *Hooks) GetHookSchedule(hookGroupId, hookId string) (*HookScheduleResponse, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) GetHookSchedule(hookGroupId, hookId string) (*HookScheduleResponse, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/schedule", new(HookScheduleResponse), nil)
-	return responseObject.(*HookScheduleResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId)+"/schedule", new(HookScheduleResponse), nil)
+	return responseObject.(*HookScheduleResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -155,10 +155,10 @@ func (myHooks *Hooks) GetHookSchedule(hookGroupId, hookId string) (*HookSchedule
 //   * assume:hook-id:<hookGroupId>/<hookId>
 //
 // See http://docs.taskcluster.net/services/hooks/#createHook
-func (myHooks *Hooks) CreateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) CreateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
-	return responseObject.(*HookDefinition), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	return responseObject.(*HookDefinition), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -171,10 +171,10 @@ func (myHooks *Hooks) CreateHook(hookGroupId, hookId string, payload *HookCreati
 //   * assume:hook-id:<hookGroupId>/<hookId>
 //
 // See http://docs.taskcluster.net/services/hooks/#updateHook
-func (myHooks *Hooks) UpdateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, *tcclient.CallSummary, error) {
+func (myHooks *Hooks) UpdateHook(hookGroupId, hookId string, payload *HookCreationRequest) (*HookDefinition, error) {
 	cd := tcclient.ConnectionData(*myHooks)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
-	return responseObject.(*HookDefinition), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), new(HookDefinition), nil)
+	return responseObject.(*HookDefinition), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -185,8 +185,8 @@ func (myHooks *Hooks) UpdateHook(hookGroupId, hookId string, payload *HookCreati
 //   * hooks:modify-hook:<hookGroupId>/<hookId>
 //
 // See http://docs.taskcluster.net/services/hooks/#removeHook
-func (myHooks *Hooks) RemoveHook(hookGroupId, hookId string) (*tcclient.CallSummary, error) {
+func (myHooks *Hooks) RemoveHook(hookGroupId, hookId string) error {
 	cd := tcclient.ConnectionData(*myHooks)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/hooks/"+url.QueryEscape(hookGroupId)+"/"+url.QueryEscape(hookId), nil, nil)
+	return err
 }

--- a/index/index.go
+++ b/index/index.go
@@ -118,7 +118,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/index/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package index
 
@@ -165,10 +165,10 @@ func New(credentials *tcclient.Credentials) *Index {
 // API end-point respond `404`.
 //
 // See http://docs.taskcluster.net/services/index/#findTask
-func (myIndex *Index) FindTask(namespace string) (*IndexedTaskResponse, *tcclient.CallSummary, error) {
+func (myIndex *Index) FindTask(namespace string) (*IndexedTaskResponse, error) {
 	cd := tcclient.ConnectionData(*myIndex)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(namespace), new(IndexedTaskResponse), nil)
-	return responseObject.(*IndexedTaskResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(namespace), new(IndexedTaskResponse), nil)
+	return responseObject.(*IndexedTaskResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -183,10 +183,10 @@ func (myIndex *Index) FindTask(namespace string) (*IndexedTaskResponse, *tcclien
 // services, as that makes little sense.
 //
 // See http://docs.taskcluster.net/services/index/#listNamespaces
-func (myIndex *Index) ListNamespaces(namespace string, payload *ListNamespacesRequest) (*ListNamespacesResponse, *tcclient.CallSummary, error) {
+func (myIndex *Index) ListNamespaces(namespace string, payload *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	cd := tcclient.ConnectionData(*myIndex)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/namespaces/"+url.QueryEscape(namespace), new(ListNamespacesResponse), nil)
-	return responseObject.(*ListNamespacesResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/namespaces/"+url.QueryEscape(namespace), new(ListNamespacesResponse), nil)
+	return responseObject.(*ListNamespacesResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -201,10 +201,10 @@ func (myIndex *Index) ListNamespaces(namespace string, payload *ListNamespacesRe
 // services, as that makes little sense.
 //
 // See http://docs.taskcluster.net/services/index/#listTasks
-func (myIndex *Index) ListTasks(namespace string, payload *ListTasksRequest) (*ListTasksResponse, *tcclient.CallSummary, error) {
+func (myIndex *Index) ListTasks(namespace string, payload *ListTasksRequest) (*ListTasksResponse, error) {
 	cd := tcclient.ConnectionData(*myIndex)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/tasks/"+url.QueryEscape(namespace), new(ListTasksResponse), nil)
-	return responseObject.(*ListTasksResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/tasks/"+url.QueryEscape(namespace), new(ListTasksResponse), nil)
+	return responseObject.(*ListTasksResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -216,10 +216,10 @@ func (myIndex *Index) ListTasks(namespace string, payload *ListTasksRequest) (*L
 //   * index:insert-task:<namespace>
 //
 // See http://docs.taskcluster.net/services/index/#insertTask
-func (myIndex *Index) InsertTask(namespace string, payload *InsertTaskRequest) (*IndexedTaskResponse, *tcclient.CallSummary, error) {
+func (myIndex *Index) InsertTask(namespace string, payload *InsertTaskRequest) (*IndexedTaskResponse, error) {
 	cd := tcclient.ConnectionData(*myIndex)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(namespace), new(IndexedTaskResponse), nil)
-	return responseObject.(*IndexedTaskResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(namespace), new(IndexedTaskResponse), nil)
+	return responseObject.(*IndexedTaskResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -232,10 +232,10 @@ func (myIndex *Index) InsertTask(namespace string, payload *InsertTaskRequest) (
 //   * queue:get-artifact:<name>
 //
 // See http://docs.taskcluster.net/services/index/#findArtifactFromTask
-func (myIndex *Index) FindArtifactFromTask(namespace, name string) (*tcclient.CallSummary, error) {
+func (myIndex *Index) FindArtifactFromTask(namespace, name string) error {
 	cd := tcclient.ConnectionData(*myIndex)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(namespace)+"/artifacts/"+url.QueryEscape(name), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(namespace)+"/artifacts/"+url.QueryEscape(name), nil, nil)
+	return err
 }
 
 // Returns a signed URL for FindArtifactFromTask, valid for the specified duration.
@@ -256,8 +256,8 @@ func (myIndex *Index) FindArtifactFromTask_SignedURL(namespace, name string, dur
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/services/index/#ping
-func (myIndex *Index) Ping() (*tcclient.CallSummary, error) {
+func (myIndex *Index) Ping() error {
 	cd := tcclient.ConnectionData(*myIndex)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/index/index.go
+++ b/index/index.go
@@ -118,7 +118,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/index/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package index
 
@@ -130,6 +130,17 @@ import (
 )
 
 type Index tcclient.ConnectionData
+
+// The AbstractIndex interface specifies the methods provided
+// by Index this is useful for mocking instances in tests.
+type AbstractIndex interface {
+	FindTask(namespace string) (*IndexedTaskResponse, error)
+	ListNamespaces(namespace string) (*ListNamespacesResponse, error)
+	ListTasks(namespace string) (*ListTasksResponse, error)
+	InsertTask(namespace string) (*IndexedTaskResponse, error)
+	FindArtifactFromTask(namespace, name string) error
+	Ping() error
+}
 
 // Returns a pointer to Index, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/purgecache/purgecache.go
+++ b/purgecache/purgecache.go
@@ -35,7 +35,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/purge-cache/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package purgecache
 
@@ -46,6 +46,13 @@ import (
 )
 
 type PurgeCache tcclient.ConnectionData
+
+// The AbstractPurgeCache interface specifies the methods provided
+// by PurgeCache this is useful for mocking instances in tests.
+type AbstractPurgeCache interface {
+	PurgeCache(provisionerId, workerType string) error
+	Ping() error
+}
 
 // Returns a pointer to PurgeCache, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/purgecache/purgecache.go
+++ b/purgecache/purgecache.go
@@ -35,7 +35,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/purge-cache/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package purgecache
 
@@ -85,10 +85,10 @@ func New(credentials *tcclient.Credentials) *PurgeCache {
 //   * purge-cache:<provisionerId>/<workerType>:<cacheName>
 //
 // See http://docs.taskcluster.net/services/purge-cache/#purgeCache
-func (purgeCache *PurgeCache) PurgeCache(provisionerId, workerType string, payload *PurgeCacheRequest) (*tcclient.CallSummary, error) {
+func (purgeCache *PurgeCache) PurgeCache(provisionerId, workerType string, payload *PurgeCacheRequest) error {
 	cd := tcclient.ConnectionData(*purgeCache)
-	_, callSummary, err := (&cd).APICall(payload, "POST", "/purge-cache/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(payload, "POST", "/purge-cache/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -98,8 +98,8 @@ func (purgeCache *PurgeCache) PurgeCache(provisionerId, workerType string, paylo
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/services/purge-cache/#ping
-func (purgeCache *PurgeCache) Ping() (*tcclient.CallSummary, error) {
+func (purgeCache *PurgeCache) Ping() error {
 	cd := tcclient.ConnectionData(*purgeCache)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -38,7 +38,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/queue/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package queue
 
@@ -50,6 +50,32 @@ import (
 )
 
 type Queue tcclient.ConnectionData
+
+// The AbstractQueue interface specifies the methods provided
+// by Queue this is useful for mocking instances in tests.
+type AbstractQueue interface {
+	Task(taskId string) (*TaskDefinitionResponse, error)
+	Status(taskId string) (*TaskStatusResponse, error)
+	ListTaskGroup(taskGroupId, continuationToken, limit string) (*ListTaskGroupResponse, error)
+	CreateTask(taskId string) (*TaskStatusResponse, error)
+	DefineTask(taskId string) (*TaskStatusResponse, error)
+	ScheduleTask(taskId string) (*TaskStatusResponse, error)
+	RerunTask(taskId string) (*TaskStatusResponse, error)
+	CancelTask(taskId string) (*TaskStatusResponse, error)
+	PollTaskUrls(provisionerId, workerType string) (*PollTaskUrlsResponse, error)
+	ClaimTask(taskId, runId string) (*TaskClaimResponse, error)
+	ReclaimTask(taskId, runId string) (*TaskReclaimResponse, error)
+	ReportCompleted(taskId, runId string) (*TaskStatusResponse, error)
+	ReportFailed(taskId, runId string) (*TaskStatusResponse, error)
+	ReportException(taskId, runId string) (*TaskStatusResponse, error)
+	CreateArtifact(taskId, runId, name string) (*PostArtifactResponse, error)
+	GetArtifact(taskId, runId, name string) error
+	GetLatestArtifact(taskId, name string) error
+	ListArtifacts(taskId, runId string) (*ListArtifactsResponse, error)
+	ListLatestArtifacts(taskId string) (*ListArtifactsResponse, error)
+	PendingTasks(provisionerId, workerType string) (*CountPendingTasksResponse, error)
+	Ping() error
+}
 
 // Returns a pointer to Queue, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -38,7 +38,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/queue/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package queue
 
@@ -84,19 +84,19 @@ func New(credentials *tcclient.Credentials) *Queue {
 // specified the queue may provide a default value.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#task
-func (myQueue *Queue) Task(taskId string) (*TaskDefinitionResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) Task(taskId string) (*TaskDefinitionResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId), new(TaskDefinitionResponse), nil)
-	return responseObject.(*TaskDefinitionResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId), new(TaskDefinitionResponse), nil)
+	return responseObject.(*TaskDefinitionResponse), err
 }
 
 // Get task status structure from `taskId`
 //
 // See http://docs.taskcluster.net/queue/api-docs/#status
-func (myQueue *Queue) Status(taskId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) Status(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/status", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/status", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // List taskIds of all tasks sharing the same `taskGroupId`.
@@ -117,13 +117,13 @@ func (myQueue *Queue) Status(taskId string) (*TaskStatusResponse, *tcclient.Call
 // use the query-string option `limit` to return fewer.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#listTaskGroup
-func (myQueue *Queue) ListTaskGroup(taskGroupId, continuationToken, limit string) (*ListTaskGroupResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ListTaskGroup(taskGroupId, continuationToken, limit string) (*ListTaskGroupResponse, error) {
 	v := url.Values{}
 	v.Add("continuationToken", continuationToken)
 	v.Add("limit", limit)
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task-group/"+url.QueryEscape(taskGroupId)+"/list", new(ListTaskGroupResponse), v)
-	return responseObject.(*ListTaskGroupResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-group/"+url.QueryEscape(taskGroupId)+"/list", new(ListTaskGroupResponse), v)
+	return responseObject.(*ListTaskGroupResponse), err
 }
 
 // Create a new task, this is an **idempotent** operation, so repeat it if
@@ -153,10 +153,10 @@ func (myQueue *Queue) ListTaskGroup(taskGroupId, continuationToken, limit string
 //   * (queue:define-task:<provisionerId>/<workerType> and queue:task-group-id:<schedulerId>/<taskGroupId> and queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>)
 //
 // See http://docs.taskcluster.net/queue/api-docs/#createTask
-func (myQueue *Queue) CreateTask(taskId string, payload *TaskDefinitionRequest) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) CreateTask(taskId string, payload *TaskDefinitionRequest) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(taskId), new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task/"+url.QueryEscape(taskId), new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // Define a task without scheduling it. This API end-point allows you to
@@ -183,10 +183,10 @@ func (myQueue *Queue) CreateTask(taskId string, payload *TaskDefinitionRequest) 
 //   * (queue:define-task:<provisionerId>/<workerType> and queue:task-group-id:<schedulerId>/<taskGroupId>)
 //
 // See http://docs.taskcluster.net/queue/api-docs/#defineTask
-func (myQueue *Queue) DefineTask(taskId string, payload *TaskDefinitionRequest) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) DefineTask(taskId string, payload *TaskDefinitionRequest) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/define", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/define", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // If you have define a task using `defineTask` API end-point, then you
@@ -203,10 +203,10 @@ func (myQueue *Queue) DefineTask(taskId string, payload *TaskDefinitionRequest) 
 //   * queue:schedule-task:<schedulerId>/<taskGroupId>/<taskId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#scheduleTask
-func (myQueue *Queue) ScheduleTask(taskId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ScheduleTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/schedule", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/schedule", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // Stability: *** DEPRECATED ***
@@ -229,10 +229,10 @@ func (myQueue *Queue) ScheduleTask(taskId string) (*TaskStatusResponse, *tcclien
 //   * queue:rerun-task:<schedulerId>/<taskGroupId>/<taskId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#rerunTask
-func (myQueue *Queue) RerunTask(taskId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) RerunTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/rerun", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/rerun", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // This method will cancel a task that is either `unscheduled`, `pending` or
@@ -253,10 +253,10 @@ func (myQueue *Queue) RerunTask(taskId string) (*TaskStatusResponse, *tcclient.C
 //   * queue:cancel-task:<schedulerId>/<taskGroupId>/<taskId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#cancelTask
-func (myQueue *Queue) CancelTask(taskId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) CancelTask(taskId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/cancel", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/cancel", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // Get a signed URLs to get and delete messages from azure queue.
@@ -268,10 +268,10 @@ func (myQueue *Queue) CancelTask(taskId string) (*TaskStatusResponse, *tcclient.
 //   * queue:poll-task-urls:<provisionerId>/<workerType>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#pollTaskUrls
-func (myQueue *Queue) PollTaskUrls(provisionerId, workerType string) (*PollTaskUrlsResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) PollTaskUrls(provisionerId, workerType string) (*PollTaskUrlsResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/poll-task-url/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), new(PollTaskUrlsResponse), nil)
-	return responseObject.(*PollTaskUrlsResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/poll-task-url/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), new(PollTaskUrlsResponse), nil)
+	return responseObject.(*PollTaskUrlsResponse), err
 }
 
 // Returns a signed URL for PollTaskUrls, valid for the specified duration.
@@ -293,10 +293,10 @@ func (myQueue *Queue) PollTaskUrls_SignedURL(provisionerId, workerType string, d
 //   * (queue:claim-task:<provisionerId>/<workerType> and queue:worker-id:<workerGroup>/<workerId>)
 //
 // See http://docs.taskcluster.net/queue/api-docs/#claimTask
-func (myQueue *Queue) ClaimTask(taskId, runId string, payload *TaskClaimRequest) (*TaskClaimResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ClaimTask(taskId, runId string, payload *TaskClaimRequest) (*TaskClaimResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/claim", new(TaskClaimResponse), nil)
-	return responseObject.(*TaskClaimResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/claim", new(TaskClaimResponse), nil)
+	return responseObject.(*TaskClaimResponse), err
 }
 
 // reclaim a task more to be added later...
@@ -306,10 +306,10 @@ func (myQueue *Queue) ClaimTask(taskId, runId string, payload *TaskClaimRequest)
 //   * queue:reclaim-task:<taskId>/<runId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#reclaimTask
-func (myQueue *Queue) ReclaimTask(taskId, runId string) (*TaskReclaimResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ReclaimTask(taskId, runId string) (*TaskReclaimResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/reclaim", new(TaskReclaimResponse), nil)
-	return responseObject.(*TaskReclaimResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/reclaim", new(TaskReclaimResponse), nil)
+	return responseObject.(*TaskReclaimResponse), err
 }
 
 // Report a task completed, resolving the run as `completed`.
@@ -319,10 +319,10 @@ func (myQueue *Queue) ReclaimTask(taskId, runId string) (*TaskReclaimResponse, *
 //   * queue:resolve-task:<taskId>/<runId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#reportCompleted
-func (myQueue *Queue) ReportCompleted(taskId, runId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ReportCompleted(taskId, runId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/completed", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/completed", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // Report a run failed, resolving the run as `failed`. Use this to resolve
@@ -338,10 +338,10 @@ func (myQueue *Queue) ReportCompleted(taskId, runId string) (*TaskStatusResponse
 //   * queue:resolve-task:<taskId>/<runId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#reportFailed
-func (myQueue *Queue) ReportFailed(taskId, runId string) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ReportFailed(taskId, runId string) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/failed", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/failed", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // Resolve a run as _exception_. Generally, you will want to report tasks as
@@ -362,10 +362,10 @@ func (myQueue *Queue) ReportFailed(taskId, runId string) (*TaskStatusResponse, *
 //   * queue:resolve-task:<taskId>/<runId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#reportException
-func (myQueue *Queue) ReportException(taskId, runId string, payload *TaskExceptionRequest) (*TaskStatusResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ReportException(taskId, runId string, payload *TaskExceptionRequest) (*TaskStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/exception", new(TaskStatusResponse), nil)
-	return responseObject.(*TaskStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/exception", new(TaskStatusResponse), nil)
+	return responseObject.(*TaskStatusResponse), err
 }
 
 // This API end-point creates an artifact for a specific run of a task. This
@@ -432,10 +432,10 @@ func (myQueue *Queue) ReportException(taskId, runId string, payload *TaskExcepti
 //   * queue:create-artifact:<taskId>/<runId>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#createArtifact
-func (myQueue *Queue) CreateArtifact(taskId, runId, name string, payload *PostArtifactRequest) (*PostArtifactResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) CreateArtifact(taskId, runId, name string, payload *PostArtifactRequest) (*PostArtifactResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), new(PostArtifactResponse), nil)
-	return responseObject.(*PostArtifactResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), new(PostArtifactResponse), nil)
+	return responseObject.(*PostArtifactResponse), err
 }
 
 // Get artifact by `<name>` from a specific run.
@@ -454,10 +454,10 @@ func (myQueue *Queue) CreateArtifact(taskId, runId, name string, payload *PostAr
 //   * queue:get-artifact:<name>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#getArtifact
-func (myQueue *Queue) GetArtifact(taskId, runId, name string) (*tcclient.CallSummary, error) {
+func (myQueue *Queue) GetArtifact(taskId, runId, name string) error {
 	cd := tcclient.ConnectionData(*myQueue)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts/"+url.QueryEscape(name), nil, nil)
+	return err
 }
 
 // Returns a signed URL for GetArtifact, valid for the specified duration.
@@ -491,10 +491,10 @@ func (myQueue *Queue) GetArtifact_SignedURL(taskId, runId, name string, duration
 //   * queue:get-artifact:<name>
 //
 // See http://docs.taskcluster.net/queue/api-docs/#getLatestArtifact
-func (myQueue *Queue) GetLatestArtifact(taskId, name string) (*tcclient.CallSummary, error) {
+func (myQueue *Queue) GetLatestArtifact(taskId, name string) error {
 	cd := tcclient.ConnectionData(*myQueue)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts/"+url.QueryEscape(name), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts/"+url.QueryEscape(name), nil, nil)
+	return err
 }
 
 // Returns a signed URL for GetLatestArtifact, valid for the specified duration.
@@ -513,10 +513,10 @@ func (myQueue *Queue) GetLatestArtifact_SignedURL(taskId, name string, duration 
 // Returns a list of artifacts and associated meta-data for a given run.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#listArtifacts
-func (myQueue *Queue) ListArtifacts(taskId, runId string) (*ListArtifactsResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ListArtifacts(taskId, runId string) (*ListArtifactsResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts", new(ListArtifactsResponse), nil)
-	return responseObject.(*ListArtifactsResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/runs/"+url.QueryEscape(runId)+"/artifacts", new(ListArtifactsResponse), nil)
+	return responseObject.(*ListArtifactsResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -525,10 +525,10 @@ func (myQueue *Queue) ListArtifacts(taskId, runId string) (*ListArtifactsRespons
 // from the given task.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#listLatestArtifacts
-func (myQueue *Queue) ListLatestArtifacts(taskId string) (*ListArtifactsResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) ListLatestArtifacts(taskId string) (*ListArtifactsResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts", new(ListArtifactsResponse), nil)
-	return responseObject.(*ListArtifactsResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task/"+url.QueryEscape(taskId)+"/artifacts", new(ListArtifactsResponse), nil)
+	return responseObject.(*ListArtifactsResponse), err
 }
 
 // Get an approximate number of pending tasks for the given `provisionerId`
@@ -540,10 +540,10 @@ func (myQueue *Queue) ListLatestArtifacts(taskId string) (*ListArtifactsResponse
 // It is, however, a solid estimate of the number of pending tasks.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#pendingTasks
-func (myQueue *Queue) PendingTasks(provisionerId, workerType string) (*CountPendingTasksResponse, *tcclient.CallSummary, error) {
+func (myQueue *Queue) PendingTasks(provisionerId, workerType string) (*CountPendingTasksResponse, error) {
 	cd := tcclient.ConnectionData(*myQueue)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/pending/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), new(CountPendingTasksResponse), nil)
-	return responseObject.(*CountPendingTasksResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/pending/"+url.QueryEscape(provisionerId)+"/"+url.QueryEscape(workerType), new(CountPendingTasksResponse), nil)
+	return responseObject.(*CountPendingTasksResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -553,8 +553,8 @@ func (myQueue *Queue) PendingTasks(provisionerId, workerType string) (*CountPend
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/queue/api-docs/#ping
-func (myQueue *Queue) Ping() (*tcclient.CallSummary, error) {
+func (myQueue *Queue) Ping() error {
 	cd := tcclient.ConnectionData(*myQueue)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -39,7 +39,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/scheduler/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package scheduler
 
@@ -50,6 +50,18 @@ import (
 )
 
 type Scheduler tcclient.ConnectionData
+
+// The AbstractScheduler interface specifies the methods provided
+// by Scheduler this is useful for mocking instances in tests.
+type AbstractScheduler interface {
+	CreateTaskGraph(taskGraphId string) (*TaskGraphStatusResponse, error)
+	ExtendTaskGraph(taskGraphId string) (*TaskGraphStatusResponse, error)
+	Status(taskGraphId string) (*TaskGraphStatusResponse, error)
+	Info(taskGraphId string) (*TaskGraphInfoResponse, error)
+	Inspect(taskGraphId string) (*InspectTaskGraphResponse, error)
+	InspectTask(taskGraphId, taskId string) (*InspectTaskGraphTaskResponse, error)
+	Ping() error
+}
 
 // Returns a pointer to Scheduler, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -39,7 +39,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/scheduler/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package scheduler
 
@@ -149,10 +149,10 @@ func New(credentials *tcclient.Credentials) *Scheduler {
 //   * scheduler:create-task-graph
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#createTaskGraph
-func (myScheduler *Scheduler) CreateTaskGraph(taskGraphId string, payload *TaskGraphDefinition) (*TaskGraphStatusResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) CreateTaskGraph(taskGraphId string, payload *TaskGraphDefinition) (*TaskGraphStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(payload, "PUT", "/task-graph/"+url.QueryEscape(taskGraphId), new(TaskGraphStatusResponse), nil)
-	return responseObject.(*TaskGraphStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "PUT", "/task-graph/"+url.QueryEscape(taskGraphId), new(TaskGraphStatusResponse), nil)
+	return responseObject.(*TaskGraphStatusResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -175,10 +175,10 @@ func (myScheduler *Scheduler) CreateTaskGraph(taskGraphId string, payload *TaskG
 //   * scheduler:extend-task-graph:<taskGraphId>
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#extendTaskGraph
-func (myScheduler *Scheduler) ExtendTaskGraph(taskGraphId string, payload *TaskGraphDefinition1) (*TaskGraphStatusResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) ExtendTaskGraph(taskGraphId string, payload *TaskGraphDefinition1) (*TaskGraphStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(payload, "POST", "/task-graph/"+url.QueryEscape(taskGraphId)+"/extend", new(TaskGraphStatusResponse), nil)
-	return responseObject.(*TaskGraphStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(payload, "POST", "/task-graph/"+url.QueryEscape(taskGraphId)+"/extend", new(TaskGraphStatusResponse), nil)
+	return responseObject.(*TaskGraphStatusResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -190,10 +190,10 @@ func (myScheduler *Scheduler) ExtendTaskGraph(taskGraphId string, payload *TaskG
 // **Note**, that `finished` implies successfully completion.
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#status
-func (myScheduler *Scheduler) Status(taskGraphId string) (*TaskGraphStatusResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) Status(taskGraphId string) (*TaskGraphStatusResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/status", new(TaskGraphStatusResponse), nil)
-	return responseObject.(*TaskGraphStatusResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/status", new(TaskGraphStatusResponse), nil)
+	return responseObject.(*TaskGraphStatusResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -206,10 +206,10 @@ func (myScheduler *Scheduler) Status(taskGraphId string) (*TaskGraphStatusRespon
 // end-point instead.
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#info
-func (myScheduler *Scheduler) Info(taskGraphId string) (*TaskGraphInfoResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) Info(taskGraphId string) (*TaskGraphInfoResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/info", new(TaskGraphInfoResponse), nil)
-	return responseObject.(*TaskGraphInfoResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/info", new(TaskGraphInfoResponse), nil)
+	return responseObject.(*TaskGraphInfoResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -228,10 +228,10 @@ func (myScheduler *Scheduler) Info(taskGraphId string) (*TaskGraphInfoResponse, 
 // the future.
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#inspect
-func (myScheduler *Scheduler) Inspect(taskGraphId string) (*InspectTaskGraphResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) Inspect(taskGraphId string) (*InspectTaskGraphResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/inspect", new(InspectTaskGraphResponse), nil)
-	return responseObject.(*InspectTaskGraphResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/inspect", new(InspectTaskGraphResponse), nil)
+	return responseObject.(*InspectTaskGraphResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -250,10 +250,10 @@ func (myScheduler *Scheduler) Inspect(taskGraphId string) (*InspectTaskGraphResp
 // the future.
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#inspectTask
-func (myScheduler *Scheduler) InspectTask(taskGraphId, taskId string) (*InspectTaskGraphTaskResponse, *tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) InspectTask(taskGraphId, taskId string) (*InspectTaskGraphTaskResponse, error) {
 	cd := tcclient.ConnectionData(*myScheduler)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/inspect/"+url.QueryEscape(taskId), new(InspectTaskGraphTaskResponse), nil)
-	return responseObject.(*InspectTaskGraphTaskResponse), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/task-graph/"+url.QueryEscape(taskGraphId)+"/inspect/"+url.QueryEscape(taskId), new(InspectTaskGraphTaskResponse), nil)
+	return responseObject.(*InspectTaskGraphTaskResponse), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -263,8 +263,8 @@ func (myScheduler *Scheduler) InspectTask(taskGraphId, taskId string) (*InspectT
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/scheduler/api-docs/#ping
-func (myScheduler *Scheduler) Ping() (*tcclient.CallSummary, error) {
+func (myScheduler *Scheduler) Ping() error {
 	cd := tcclient.ConnectionData(*myScheduler)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -32,7 +32,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/secrets/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
+// Tue, 22 Mar 2016 at 20:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package secrets
 
@@ -44,6 +44,16 @@ import (
 )
 
 type Secrets tcclient.ConnectionData
+
+// The AbstractSecrets interface specifies the methods provided
+// by Secrets this is useful for mocking instances in tests.
+type AbstractSecrets interface {
+	Set(name string) error
+	Remove(name string) error
+	Get(name string) (*Secret, error)
+	List() (*SecretsList, error)
+	Ping() error
+}
 
 // Returns a pointer to Secrets, configured to run against production.  If you
 // wish to point at a different API endpoint url, set BaseURL to the preferred

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -32,7 +32,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/secrets/v1/api.json together with the input and output schemas it references, downloaded on
-// Thu, 3 Mar 2016 at 16:15:00 UTC. The code was generated
+// Thu, 17 Mar 2016 at 19:11:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package secrets
 
@@ -81,10 +81,10 @@ func New(credentials *tcclient.Credentials) *Secrets {
 //   * secrets:set:<name>
 //
 // See http://docs.taskcluster.net/services/secrets/#set
-func (mySecrets *Secrets) Set(name string, payload *Secret) (*tcclient.CallSummary, error) {
+func (mySecrets *Secrets) Set(name string, payload *Secret) error {
 	cd := tcclient.ConnectionData(*mySecrets)
-	_, callSummary, err := (&cd).APICall(payload, "PUT", "/secret/"+url.QueryEscape(name), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(payload, "PUT", "/secret/"+url.QueryEscape(name), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -95,10 +95,10 @@ func (mySecrets *Secrets) Set(name string, payload *Secret) (*tcclient.CallSumma
 //   * secrets:set:<name>
 //
 // See http://docs.taskcluster.net/services/secrets/#remove
-func (mySecrets *Secrets) Remove(name string) (*tcclient.CallSummary, error) {
+func (mySecrets *Secrets) Remove(name string) error {
 	cd := tcclient.ConnectionData(*mySecrets)
-	_, callSummary, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.QueryEscape(name), nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "DELETE", "/secret/"+url.QueryEscape(name), nil, nil)
+	return err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -109,10 +109,10 @@ func (mySecrets *Secrets) Remove(name string) (*tcclient.CallSummary, error) {
 //   * secrets:get:<name>
 //
 // See http://docs.taskcluster.net/services/secrets/#get
-func (mySecrets *Secrets) Get(name string) (*Secret, *tcclient.CallSummary, error) {
+func (mySecrets *Secrets) Get(name string) (*Secret, error) {
 	cd := tcclient.ConnectionData(*mySecrets)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/secret/"+url.QueryEscape(name), new(Secret), nil)
-	return responseObject.(*Secret), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/secret/"+url.QueryEscape(name), new(Secret), nil)
+	return responseObject.(*Secret), err
 }
 
 // Returns a signed URL for Get, valid for the specified duration.
@@ -131,10 +131,10 @@ func (mySecrets *Secrets) Get_SignedURL(name string, duration time.Duration) (*u
 // List the names of all visible secrets.
 //
 // See http://docs.taskcluster.net/services/secrets/#list
-func (mySecrets *Secrets) List() (*SecretsList, *tcclient.CallSummary, error) {
+func (mySecrets *Secrets) List() (*SecretsList, error) {
 	cd := tcclient.ConnectionData(*mySecrets)
-	responseObject, callSummary, err := (&cd).APICall(nil, "GET", "/secrets", new(SecretsList), nil)
-	return responseObject.(*SecretsList), callSummary, err
+	responseObject, _, err := (&cd).APICall(nil, "GET", "/secrets", new(SecretsList), nil)
+	return responseObject.(*SecretsList), err
 }
 
 // Stability: *** EXPERIMENTAL ***
@@ -144,8 +144,8 @@ func (mySecrets *Secrets) List() (*SecretsList, *tcclient.CallSummary, error) {
 // **Warning** this api end-point is **not stable**.
 //
 // See http://docs.taskcluster.net/services/secrets/#ping
-func (mySecrets *Secrets) Ping() (*tcclient.CallSummary, error) {
+func (mySecrets *Secrets) Ping() error {
 	cd := tcclient.ConnectionData(*mySecrets)
-	_, callSummary, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
-	return callSummary, err
+	_, _, err := (&cd).APICall(nil, "GET", "/ping", nil, nil)
+	return err
 }

--- a/tcclient/creds_test.go
+++ b/tcclient/creds_test.go
@@ -71,7 +71,7 @@ func checkAuthenticate(t *testing.T, response *auth.TestAuthenticateResponse, er
 
 func Test_PermaCred(t *testing.T) {
 	client := auth.New(testCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:this"},
 	})
@@ -86,7 +86,7 @@ func Test_TempCred(t *testing.T) {
 		return
 	}
 	client := auth.New(tempCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
 	})
@@ -102,7 +102,7 @@ func Test_NamedTempCred(t *testing.T) {
 		return
 	}
 	client := auth.New(tempCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*", "auth:create-client:jimmy"},
 		RequiredScopes: []string{"scope:1"},
 	})
@@ -149,7 +149,7 @@ func Test_AuthorizedScopes(t *testing.T) {
 	authCreds := *testCreds
 	authCreds.AuthorizedScopes = []string{"scope:1", "scope:3"}
 	client := auth.New(&authCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
 	})
@@ -165,7 +165,7 @@ func Test_TempCredWithAuthorizedScopes(t *testing.T) {
 	}
 	tempCreds.AuthorizedScopes = []string{"scope:1"}
 	client := auth.New(tempCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
 	})
@@ -182,7 +182,7 @@ func Test_NamedTempCredWithAuthorizedScopes(t *testing.T) {
 	}
 	tempCreds.AuthorizedScopes = []string{"scope:1"} // note: no create-client
 	client := auth.New(tempCreds)
-	response, _, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
+	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*", "auth:create-client:j*"},
 		RequiredScopes: []string{"scope:1"},
 	})


### PR DESCRIPTION
This is on top of the remove `CallSummary`
It just adds an `AbstractQueue`, etc.... interfaces.. So it's easier to generate good mocks.

We should probably make a mock package containing MockQueue objects and things like that... It would be really nice to just have it from here... Rather than having to do it everywhere else...

I'm also okay with throwing the `MockQueue` into the `queue` package... Really the go compiler probably removes code that isn't referenced (after all these are statically linked binaries).
