### PR TITLE
Allow users to pass in their own http.Client

### DIFF
--- a/creds.go
+++ b/creds.go
@@ -56,6 +56,9 @@ type Client struct {
 	// Please note calling auth.New(clientId string, accessToken string) is an
 	// alternative way to create an Auth object with Authenticate set to true.
 	Authenticate bool
+	// HTTPClient is a ReducedHTTPClient to be used for the http call instead of
+	// the DefaultHTTPClient.
+	HTTPClient ReducedHTTPClient
 }
 
 // Certificate represents the certificate used in Temporary Credentials. See

--- a/http.go
+++ b/http.go
@@ -49,10 +49,16 @@ type APICall struct {
 	Payload     io.Reader
 }
 
+// ReducedHTTPClient is the interface that wraps the functionality of
+// http.Client that we actually use in Client.APICall.
+type ReducedHTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // DefaultHTTPClient is the HTTP Client used to make requests.
 // A single object is created an used because http.Client is thread-safe when
 // making multiple requests in various goroutines.
-var DefaultHTTPClient = &http.Client{}
+var DefaultHTTPClient ReducedHTTPClient = &http.Client{}
 
 // utility function to create a URL object based on given data
 func setURL(client *Client, route string, query url.Values) (u *url.URL, err error) {

--- a/http.go
+++ b/http.go
@@ -55,8 +55,9 @@ type ReducedHTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// DefaultHTTPClient is the HTTP Client used to make requests.
-// A single object is created an used because http.Client is thread-safe when
+// DefaultHTTPClient is the HTTP Client used to make requests if none are
+// defined in the client.
+// A single object is created and used because http.Client is thread-safe when
 // making multiple requests in various goroutines.
 var DefaultHTTPClient ReducedHTTPClient = &http.Client{}
 
@@ -103,7 +104,12 @@ func (client *Client) Request(rawPayload []byte, method, route string, query url
 				return nil, nil, err
 			}
 		}
-		resp, err := DefaultHTTPClient.Do(callSummary.HTTPRequest)
+		var resp *http.Response
+		if client.HTTPClient != nil {
+			resp, err = client.HTTPClient.Do(callSummary.HTTPRequest)
+		} else {
+			resp, err = DefaultHTTPClient.Do(callSummary.HTTPRequest)
+		}
 		// b, e := httputil.DumpResponse(resp, true)
 		// if e == nil {
 		// 	fmt.Println(string(b))

--- a/http.go
+++ b/http.go
@@ -55,11 +55,11 @@ type ReducedHTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// DefaultHTTPClient is the HTTP Client used to make requests if none are
+// defaultHTTPClient is the HTTP Client used to make requests if none are
 // defined in the client.
 // A single object is created and used because http.Client is thread-safe when
 // making multiple requests in various goroutines.
-var DefaultHTTPClient ReducedHTTPClient = &http.Client{}
+var defaultHTTPClient ReducedHTTPClient = &http.Client{}
 
 // utility function to create a URL object based on given data
 func setURL(client *Client, route string, query url.Values) (u *url.URL, err error) {
@@ -108,7 +108,7 @@ func (client *Client) Request(rawPayload []byte, method, route string, query url
 		if client.HTTPClient != nil {
 			resp, err = client.HTTPClient.Do(callSummary.HTTPRequest)
 		} else {
-			resp, err = DefaultHTTPClient.Do(callSummary.HTTPRequest)
+			resp, err = defaultHTTPClient.Do(callSummary.HTTPRequest)
 		}
 		// b, e := httputil.DumpResponse(resp, true)
 		// if e == nil {

--- a/http.go
+++ b/http.go
@@ -49,6 +49,11 @@ type APICall struct {
 	Payload     io.Reader
 }
 
+// DefaultHTTPClient is the HTTP Client used to make requests.
+// A single object is created an used because http.Client is thread-safe when
+// making multiple requests in various goroutines.
+var DefaultHTTPClient = &http.Client{}
+
 // utility function to create a URL object based on given data
 func setURL(client *Client, route string, query url.Values) (u *url.URL, err error) {
 	u, err = url.Parse(client.BaseURL + route)
@@ -92,7 +97,7 @@ func (client *Client) Request(rawPayload []byte, method, route string, query url
 				return nil, nil, err
 			}
 		}
-		resp, err := (&http.Client{}).Do(callSummary.HTTPRequest)
+		resp, err := DefaultHTTPClient.Do(callSummary.HTTPRequest)
 		// b, e := httputil.DumpResponse(resp, true)
 		// if e == nil {
 		// 	fmt.Println(string(b))


### PR DESCRIPTION
Right now the library defaults to using a new default http client for each `APICall` call. Instead, the library should expose a `HTTPClient` field in the `Client` struct that is used for all the requests.

This would allow users to pass in modified http client that fits their need better than the default http client.