### PR TITLE
Add a standard function to load credentials from the environment

### DIFF
--- a/auth/auth_examples_test.go
+++ b/auth/auth_examples_test.go
@@ -3,7 +3,6 @@ package auth_test
 import (
 	"fmt"
 	"log"
-	"os"
 	"time"
 
 	tcclient "github.com/taskcluster/taskcluster-client-go"
@@ -15,13 +14,18 @@ func Example_scopes() {
 	// Note: the API call we will make doesn't need credentials as it supplies public information.
 	// However, for the purpose of demonstrating the general case, this is how you can provide
 	// credentials for API calls that require them.
-	myAuth := auth.New(
+	myAuth, err := auth.New(
 		&tcclient.Credentials{
-			ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-			AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-			Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+			ClientID:    "SOME-CLIENT-ID",
+			AccessToken: "SOME-WELL-FORMED-ACCESS-TOKEN",
 		},
 	)
+
+	// Handle any errors...
+	if err != nil {
+		log.Printf("Error occurred: %s", err)
+		return
+	}
 
 	// Look up client details for client id "project/taskcluster/tc-client-go/tests"...
 	resp, err := myAuth.Client("project/taskcluster/tc-client-go/tests")
@@ -48,12 +52,9 @@ func Example_updateClient() {
 	// In this example we will connect to a local auth server running on
 	// localhost with authentication disabled. This would also work for
 	// connecting to a local taskcluster-proxy instance.
-	myAuth := auth.New(
-		&tcclient.Credentials{},
-	)
+	myAuth := auth.NewNoAuth()
 
-	// Disable authentication and set target url to localhost url...
-	myAuth.Authenticate = false
+	// Set target url to localhost url...
 	myAuth.BaseURL = "http://localhost:60024/v1"
 
 	// Update client id "b2g-power-tests" with new description and expiry...

--- a/creds_hmac_test.go
+++ b/creds_hmac_test.go
@@ -59,7 +59,7 @@ func testCreds(t *testing.T, tc *TempCredsTestCase) {
 	}
 	cert.Start = start.UnixNano() / 1e6
 	cert.Expiry = expiry.UnixNano() / 1e6
-	cert.updateSignature(permCreds.AccessToken, tempCreds.ClientID)
+	cert.Sign(permCreds.AccessToken, tempCreds.ClientID)
 	certBytes, err := json.Marshal(cert)
 	if err != nil {
 		t.Fatalf("Could not convert updated certificate into a string: %s", err)

--- a/creds_test.go
+++ b/creds_test.go
@@ -70,7 +70,10 @@ func checkAuthenticate(t *testing.T, response *auth.TestAuthenticateResponse, er
 }
 
 func Test_PermaCred(t *testing.T) {
-	client := auth.New(testCreds)
+	client, err := auth.New(testCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:this"},
@@ -85,7 +88,10 @@ func Test_TempCred(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	client := auth.New(tempCreds)
+	client, err := auth.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
@@ -101,7 +107,10 @@ func Test_NamedTempCred(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	client := auth.New(tempCreds)
+	client, err := auth.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*", "auth:create-client:jimmy"},
 		RequiredScopes: []string{"scope:1"},
@@ -148,7 +157,10 @@ func Test_TempCred_TooLong(t *testing.T) {
 func Test_AuthorizedScopes(t *testing.T) {
 	authCreds := *testCreds
 	authCreds.AuthorizedScopes = []string{"scope:1", "scope:3"}
-	client := auth.New(&authCreds)
+	client, err := auth.New(&authCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
@@ -164,7 +176,10 @@ func Test_TempCredWithAuthorizedScopes(t *testing.T) {
 		return
 	}
 	tempCreds.AuthorizedScopes = []string{"scope:1"}
-	client := auth.New(tempCreds)
+	client, err := auth.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*"},
 		RequiredScopes: []string{"scope:1"},
@@ -181,7 +196,10 @@ func Test_NamedTempCredWithAuthorizedScopes(t *testing.T) {
 		return
 	}
 	tempCreds.AuthorizedScopes = []string{"scope:1"} // note: no create-client
-	client := auth.New(tempCreds)
+	client, err := auth.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	response, err := client.TestAuthenticate(&auth.TestAuthenticateRequest{
 		ClientScopes:   []string{"scope:*", "auth:create-client:j*"},
 		RequiredScopes: []string{"scope:1"},

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -24,9 +24,8 @@ import (
 // Note, no credentials are needed, so this can be run even on travis-ci.org,
 // for example.
 func TestFindLatestLinux64DebugBuild(t *testing.T) {
-	creds := &tcclient.Credentials{}
-	Index := index.New(creds)
-	Queue := queue.New(creds)
+	Index := index.NewNoAuth()
+	Queue := queue.NewNoAuth()
 	itr, err := Index.FindTask("gecko.v2.mozilla-inbound.latest.firefox.linux64-debug")
 	if err != nil {
 		t.Fatalf("%v\n", err)
@@ -71,7 +70,10 @@ func permaCreds(t *testing.T) *tcclient.Credentials {
 // Tests whether it is possible to define a task against the production Queue.
 func TestDefineTask(t *testing.T) {
 	permaCreds := permaCreds(t)
-	myQueue := queue.New(permaCreds)
+	myQueue, err := queue.New(permaCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 
 	taskID := slugid.Nice()
 	taskGroupID := slugid.Nice()
@@ -207,7 +209,10 @@ func TestDefineTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Exception thrown generating temporary credentials!\n\n%s\n\n", err)
 	}
-	myQueue = queue.New(tempCreds)
+	myQueue, err = queue.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	_, err = myQueue.CancelTask(taskID)
 	if err != nil {
 		t.Fatalf("Exception thrown cancelling task with temporary credentials!\n\n%s\n\n", err)

--- a/integrationtest/signedurls_test.go
+++ b/integrationtest/signedurls_test.go
@@ -18,7 +18,10 @@ import (
 func TestSignedURLPermCredsAuthScopes(t *testing.T) {
 	permaCreds := permaCreds(t)
 	permaCreds.AuthorizedScopes = []string{"queue:get-artifact:private/build/sources.xml"}
-	myQueue := queue.New(permaCreds)
+	myQueue, err := queue.New(permaCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	createAndTestExampleSignedURL(myQueue, t)
 }
 
@@ -28,7 +31,10 @@ func TestSignedURLPermCredsAuthScopes(t *testing.T) {
 // and that the signed URL returns the protected content when queried.
 func TestSignedURLPermCreds(t *testing.T) {
 	permaCreds := permaCreds(t)
-	myQueue := queue.New(permaCreds)
+	myQueue, err := queue.New(permaCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	createAndTestExampleSignedURL(myQueue, t)
 }
 
@@ -39,7 +45,10 @@ func TestSignedURLPermCreds(t *testing.T) {
 func TestBadAuthScopesSignedURL(t *testing.T) {
 	permaCreds := permaCreds(t)
 	permaCreds.AuthorizedScopes = []string{"queue:task-priority:high"}
-	myQueue := queue.New(permaCreds)
+	myQueue, err := queue.New(permaCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	signedURL, err := myQueue.GetArtifact_SignedURL("X_WYg5S6QvKqMmmAgGo8ng", "0", "private/build/sources.xml", time.Second*30)
 	if err != nil {
 		t.Fatalf("Exception thrown signing URL\n%s", err)
@@ -70,7 +79,10 @@ func TestSignedURLTempCreds(t *testing.T) {
 	if err != nil {
 		t.Fatal("Exception creating temporary credentials")
 	}
-	myQueue := queue.New(tempCreds)
+	myQueue, err := queue.New(tempCreds)
+	if err != nil {
+		t.Fatalf("%v\n", err)
+	}
 	createAndTestExampleSignedURL(myQueue, t)
 }
 

--- a/login/login.go
+++ b/login/login.go
@@ -41,32 +41,46 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
+const (
+	DefaultBaseURL = "https://login.taskcluster.net/v1"
+)
+
 type Login tcclient.Client
 
-// Returns a pointer to Login, configured to run against production.  If you
-// wish to point at a different API endpoint url, set BaseURL to the preferred
-// url. Authentication can be disabled (for example if you wish to use the
-// taskcluster-proxy) by setting Authenticate to false (in which case creds is
-// ignored).
+// New returns a Login client, configured to run against production. Pass in
+// nil to load credentials from TASKCLUSTER_* environment variables. The
+// returned client is mutable, so returned settings can be altered.
 //
-// For example:
-//  creds := &tcclient.Credentials{
-//  	ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-//  	AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-//  	Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+//  myLogin, err := login.New(nil)                           // credentials loaded from TASKCLUSTER_* env vars
+//  if err != nil {
+//      // handle malformed credentials...
 //  }
-//  myLogin := login.New(creds)                              // set credentials
-//  myLogin.Authenticate = false                             // disable authentication (creds above are now ignored)
 //  myLogin.BaseURL = "http://localhost:1234/api/Login/v1"   // alternative API endpoint (production by default)
 //  data, err := myLogin.OidcCredentials(.....)              // for example, call the OidcCredentials(.....) API endpoint (described further down)...
 //  if err != nil {
 //  	// handle errors...
 //  }
-func New(credentials *tcclient.Credentials) *Login {
+//
+// If authentication is not required, use NewNoAuth() instead.
+func New(credentials *tcclient.Credentials) (*Login, error) {
+	if credentials == nil {
+		credentials = tcclient.CredentialsFromEnvVars()
+	}
+	err := credentials.Validate()
 	myLogin := Login(tcclient.Client{
 		Credentials:  credentials,
-		BaseURL:      "https://login.taskcluster.net/v1",
+		BaseURL:      DefaultBaseURL,
 		Authenticate: true,
+	})
+	return &myLogin, err
+}
+
+// NewNoAuth returns a Login client with authentication disabled. This is
+// useful when calling taskcluster APIs that do not require authorization.
+func NewNoAuth() *Login {
+	myLogin := Login(tcclient.Client{
+		BaseURL:      DefaultBaseURL,
+		Authenticate: false,
 	})
 	return &myLogin
 }

--- a/notify/notify.go
+++ b/notify/notify.go
@@ -40,32 +40,46 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
+const (
+	DefaultBaseURL = "https://notify.taskcluster.net/v1"
+)
+
 type Notify tcclient.Client
 
-// Returns a pointer to Notify, configured to run against production.  If you
-// wish to point at a different API endpoint url, set BaseURL to the preferred
-// url. Authentication can be disabled (for example if you wish to use the
-// taskcluster-proxy) by setting Authenticate to false (in which case creds is
-// ignored).
+// New returns a Notify client, configured to run against production. Pass in
+// nil to load credentials from TASKCLUSTER_* environment variables. The
+// returned client is mutable, so returned settings can be altered.
 //
-// For example:
-//  creds := &tcclient.Credentials{
-//  	ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-//  	AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-//  	Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+//  myNotify, err := notify.New(nil)                           // credentials loaded from TASKCLUSTER_* env vars
+//  if err != nil {
+//      // handle malformed credentials...
 //  }
-//  myNotify := notify.New(creds)                              // set credentials
-//  myNotify.Authenticate = false                              // disable authentication (creds above are now ignored)
 //  myNotify.BaseURL = "http://localhost:1234/api/Notify/v1"   // alternative API endpoint (production by default)
 //  err := myNotify.Email(.....)                               // for example, call the Email(.....) API endpoint (described further down)...
 //  if err != nil {
 //  	// handle errors...
 //  }
-func New(credentials *tcclient.Credentials) *Notify {
+//
+// If authentication is not required, use NewNoAuth() instead.
+func New(credentials *tcclient.Credentials) (*Notify, error) {
+	if credentials == nil {
+		credentials = tcclient.CredentialsFromEnvVars()
+	}
+	err := credentials.Validate()
 	myNotify := Notify(tcclient.Client{
 		Credentials:  credentials,
-		BaseURL:      "https://notify.taskcluster.net/v1",
+		BaseURL:      DefaultBaseURL,
 		Authenticate: true,
+	})
+	return &myNotify, err
+}
+
+// NewNoAuth returns a Notify client with authentication disabled. This is
+// useful when calling taskcluster APIs that do not require authorization.
+func NewNoAuth() *Notify {
+	myNotify := Notify(tcclient.Client{
+		BaseURL:      DefaultBaseURL,
+		Authenticate: false,
 	})
 	return &myNotify
 }

--- a/purgecache/purgecache.go
+++ b/purgecache/purgecache.go
@@ -45,32 +45,46 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
+const (
+	DefaultBaseURL = "https://purge-cache.taskcluster.net/v1"
+)
+
 type PurgeCache tcclient.Client
 
-// Returns a pointer to PurgeCache, configured to run against production.  If you
-// wish to point at a different API endpoint url, set BaseURL to the preferred
-// url. Authentication can be disabled (for example if you wish to use the
-// taskcluster-proxy) by setting Authenticate to false (in which case creds is
-// ignored).
+// New returns a PurgeCache client, configured to run against production. Pass in
+// nil to load credentials from TASKCLUSTER_* environment variables. The
+// returned client is mutable, so returned settings can be altered.
 //
-// For example:
-//  creds := &tcclient.Credentials{
-//  	ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-//  	AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-//  	Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+//  purgeCache, err := purgecache.New(nil)                           // credentials loaded from TASKCLUSTER_* env vars
+//  if err != nil {
+//      // handle malformed credentials...
 //  }
-//  purgeCache := purgecache.New(creds)                              // set credentials
-//  purgeCache.Authenticate = false                                  // disable authentication (creds above are now ignored)
 //  purgeCache.BaseURL = "http://localhost:1234/api/PurgeCache/v1"   // alternative API endpoint (production by default)
 //  err := purgeCache.PurgeCache(.....)                              // for example, call the PurgeCache(.....) API endpoint (described further down)...
 //  if err != nil {
 //  	// handle errors...
 //  }
-func New(credentials *tcclient.Credentials) *PurgeCache {
+//
+// If authentication is not required, use NewNoAuth() instead.
+func New(credentials *tcclient.Credentials) (*PurgeCache, error) {
+	if credentials == nil {
+		credentials = tcclient.CredentialsFromEnvVars()
+	}
+	err := credentials.Validate()
 	purgeCache := PurgeCache(tcclient.Client{
 		Credentials:  credentials,
-		BaseURL:      "https://purge-cache.taskcluster.net/v1",
+		BaseURL:      DefaultBaseURL,
 		Authenticate: true,
+	})
+	return &purgeCache, err
+}
+
+// NewNoAuth returns a PurgeCache client with authentication disabled. This is
+// useful when calling taskcluster APIs that do not require authorization.
+func NewNoAuth() *PurgeCache {
+	purgeCache := PurgeCache(tcclient.Client{
+		BaseURL:      DefaultBaseURL,
+		Authenticate: false,
 	})
 	return &purgeCache
 }

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -49,32 +49,46 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
+const (
+	DefaultBaseURL = "https://queue.taskcluster.net/v1"
+)
+
 type Queue tcclient.Client
 
-// Returns a pointer to Queue, configured to run against production.  If you
-// wish to point at a different API endpoint url, set BaseURL to the preferred
-// url. Authentication can be disabled (for example if you wish to use the
-// taskcluster-proxy) by setting Authenticate to false (in which case creds is
-// ignored).
+// New returns a Queue client, configured to run against production. Pass in
+// nil to load credentials from TASKCLUSTER_* environment variables. The
+// returned client is mutable, so returned settings can be altered.
 //
-// For example:
-//  creds := &tcclient.Credentials{
-//  	ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-//  	AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-//  	Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+//  myQueue, err := queue.New(nil)                           // credentials loaded from TASKCLUSTER_* env vars
+//  if err != nil {
+//      // handle malformed credentials...
 //  }
-//  myQueue := queue.New(creds)                              // set credentials
-//  myQueue.Authenticate = false                             // disable authentication (creds above are now ignored)
 //  myQueue.BaseURL = "http://localhost:1234/api/Queue/v1"   // alternative API endpoint (production by default)
 //  data, err := myQueue.Task(.....)                         // for example, call the Task(.....) API endpoint (described further down)...
 //  if err != nil {
 //  	// handle errors...
 //  }
-func New(credentials *tcclient.Credentials) *Queue {
+//
+// If authentication is not required, use NewNoAuth() instead.
+func New(credentials *tcclient.Credentials) (*Queue, error) {
+	if credentials == nil {
+		credentials = tcclient.CredentialsFromEnvVars()
+	}
+	err := credentials.Validate()
 	myQueue := Queue(tcclient.Client{
 		Credentials:  credentials,
-		BaseURL:      "https://queue.taskcluster.net/v1",
+		BaseURL:      DefaultBaseURL,
 		Authenticate: true,
+	})
+	return &myQueue, err
+}
+
+// NewNoAuth returns a Queue client with authentication disabled. This is
+// useful when calling taskcluster APIs that do not require authorization.
+func NewNoAuth() *Queue {
+	myQueue := Queue(tcclient.Client{
+		BaseURL:      DefaultBaseURL,
+		Authenticate: false,
 	})
 	return &myQueue
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -47,32 +47,46 @@ import (
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
+const (
+	DefaultBaseURL = "https://secrets.taskcluster.net/v1"
+)
+
 type Secrets tcclient.Client
 
-// Returns a pointer to Secrets, configured to run against production.  If you
-// wish to point at a different API endpoint url, set BaseURL to the preferred
-// url. Authentication can be disabled (for example if you wish to use the
-// taskcluster-proxy) by setting Authenticate to false (in which case creds is
-// ignored).
+// New returns a Secrets client, configured to run against production. Pass in
+// nil to load credentials from TASKCLUSTER_* environment variables. The
+// returned client is mutable, so returned settings can be altered.
 //
-// For example:
-//  creds := &tcclient.Credentials{
-//  	ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
-//  	AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
-//  	Certificate: os.Getenv("TASKCLUSTER_CERTIFICATE"),
+//  mySecrets, err := secrets.New(nil)                           // credentials loaded from TASKCLUSTER_* env vars
+//  if err != nil {
+//      // handle malformed credentials...
 //  }
-//  mySecrets := secrets.New(creds)                              // set credentials
-//  mySecrets.Authenticate = false                               // disable authentication (creds above are now ignored)
 //  mySecrets.BaseURL = "http://localhost:1234/api/Secrets/v1"   // alternative API endpoint (production by default)
 //  err := mySecrets.Set(.....)                                  // for example, call the Set(.....) API endpoint (described further down)...
 //  if err != nil {
 //  	// handle errors...
 //  }
-func New(credentials *tcclient.Credentials) *Secrets {
+//
+// If authentication is not required, use NewNoAuth() instead.
+func New(credentials *tcclient.Credentials) (*Secrets, error) {
+	if credentials == nil {
+		credentials = tcclient.CredentialsFromEnvVars()
+	}
+	err := credentials.Validate()
 	mySecrets := Secrets(tcclient.Client{
 		Credentials:  credentials,
-		BaseURL:      "https://secrets.taskcluster.net/v1",
+		BaseURL:      DefaultBaseURL,
 		Authenticate: true,
+	})
+	return &mySecrets, err
+}
+
+// NewNoAuth returns a Secrets client with authentication disabled. This is
+// useful when calling taskcluster APIs that do not require authorization.
+func NewNoAuth() *Secrets {
+	mySecrets := Secrets(tcclient.Client{
+		BaseURL:      DefaultBaseURL,
+		Authenticate: false,
 	})
 	return &mySecrets
 }


### PR DESCRIPTION
This function is useful to implementors of the library which are to be used on
the command line.  Having a stanard method defined in the main client library
means that we can have identical behaviour across multiple consumers of the
library.  My proposal is to add loading credentials from configuration files.
For all cases, I think that a non-fatal error for this function is the right
action to take, so that if something goes wrong while loading a file, we just
return a nil value Credential.  I'm also happy to have it return an error and
have the caller ignore the error explicitly.  If we do that, we should add an
error return to this function