### PR TITLE
Updated clientId regexp as per taskcluster/taskcluster-auth#137

### DIFF
--- a/creds.go
+++ b/creds.go
@@ -38,7 +38,7 @@ type Credentials struct {
 }
 
 var (
-	RegExpClientID    *regexp.Regexp = regexp.MustCompile(`^[A-Za-z0-9@/:.+|_-]+$`)
+	RegExpClientID    *regexp.Regexp = regexp.MustCompile(`^[A-Za-z0-9!@/:.+|_-]+$`)
 	RegExpAccessToken *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z0-9_-]{22,66}$`)
 )
 


### PR DESCRIPTION
As @jonasfj pointed out, the client shouldn't really be making these checks, but since it is, we should probably use the new `clientId` format. At some point we should remove these checks.... 