### PR TITLE
Non nested structs

### DIFF
--- a/codegenerator/model-data.txt
+++ b/codegenerator/model-data.txt
@@ -1,4 +1,4 @@
-Generated: 1523884934
+Generated: 1523890865
 The following file is an auto-generated static dump of the API models at time of code generation.
 It is provided here for reference purposes, but is not used by any code.
 
@@ -1157,6 +1157,65 @@ required:
 - credentials
 - expires
 title: AWS S3 Credentials Response
+type: object
+
+
+http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials
+===============================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials
+TYPE_NAME: TemporarySecurityCredentials
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Temporary STS credentials for use when operating on S3
+properties:
+  MemberNames:
+    accessKeyId: AccessKeyID
+    secretAccessKey: SecretAccessKey
+    sessionToken: SessionToken
+  Properties:
+    accessKeyId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessKeyId
+      SOURCE_URL: http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/accessKeyId
+      TYPE_NAME: AccessKeyID
+      description: |
+        Access key identifier that identifies the temporary security
+        credentials.
+      title: AccessKeyId
+      type: string
+    secretAccessKey:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secretAccessKey
+      SOURCE_URL: http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/secretAccessKey
+      TYPE_NAME: SecretAccessKey
+      description: |
+        Secret access key used to sign requests
+      title: SecretAccessKey
+      type: string
+    sessionToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: sessionToken
+      SOURCE_URL: http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/sessionToken
+      TYPE_NAME: SessionToken
+      description: |
+        A token that must passed with request to use the temporary
+        security credentials.
+      title: SessionToken
+      type: string
+  SortedPropertyNames:
+  - accessKeyId
+  - secretAccessKey
+  - sessionToken
+  SourceURL: http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties
+required:
+- accessKeyId
+- secretAccessKey
+- sessionToken
+title: Temporary Security Credentials
 type: object
 
 
@@ -2507,6 +2566,57 @@ required:
 - dsn
 - expires
 title: Sentry DSN Response
+type: object
+
+
+http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn
+===============================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: dsn
+SOURCE_URL: http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn
+TYPE_NAME: Dsn
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Access credentials and urls for the Sentry project.
+  Credentials will expire in 24-48 hours, you should refresh them within
+  24 hours.
+properties:
+  MemberNames:
+    public: Public
+    secret: Secret
+  Properties:
+    public:
+      IS_REQUIRED: true
+      PROPERTY_NAME: public
+      SOURCE_URL: http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/public
+      TYPE_NAME: Public
+      description: |
+        Access credential and URL for public error reports.
+        These credentials can be used for up-to 24 hours.
+        This is for use in client-side applications only.
+      format: uri
+      type: string
+    secret:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secret
+      SOURCE_URL: http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/secret
+      TYPE_NAME: Secret
+      description: |
+        Access credential and URL for private error reports.
+        These credentials can be used for up-to 24 hours.
+        This is for use in serser-side applications and should **not** be
+        leaked.
+      format: uri
+      type: string
+  SortedPropertyNames:
+  - public
+  - secret
+  SourceURL: http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties
+required:
+- secret
+- public
 type: object
 
 
@@ -3903,6 +4013,326 @@ title: Create Worker Type Request
 type: object
 
 
+http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items
+=====================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: availabilityZones entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items
+TYPE_NAME: AvailabilityZonesEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Availability zone configuration
+properties:
+  MemberNames:
+    availabilityZone: AvailabilityZone
+    launchSpec: LaunchSpec
+    region: Region
+    secrets: Secrets
+    userData: UserData
+  Properties:
+    availabilityZone:
+      IS_REQUIRED: true
+      PROPERTY_NAME: availabilityZone
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/availabilityZone
+      TYPE_NAME: AvailabilityZone
+      description: |
+        The AWS availability zone being configured.  Example: eu-central-1b
+      type: string
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec
+      description: |
+        LaunchSpecification entries unique to this AZ
+      type: object
+    region:
+      IS_REQUIRED: true
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/region
+      TYPE_NAME: Region
+      description: |
+        The AWS region containing this availability zone.  Example: eu-central-1
+      type: string
+    secrets:
+      IS_REQUIRED: false
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/secrets
+      TYPE_NAME: Secrets
+      default: {}
+      description: |
+        Static Secrets unique to this AZ
+      type: object
+    userData:
+      IS_REQUIRED: false
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/userData
+      TYPE_NAME: UserData
+      default: {}
+      description: |
+        UserData entries unique to this AZ
+      type: object
+  SortedPropertyNames:
+  - availabilityZone
+  - launchSpec
+  - region
+  - secrets
+  - userData
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties
+required:
+- region
+- availabilityZone
+- launchSpec
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items
+=================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: instanceTypes entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items
+TYPE_NAME: InstanceTypesEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Instance Type configuration
+properties:
+  MemberNames:
+    capacity: Capacity
+    instanceType: InstanceType
+    launchSpec: LaunchSpec
+    scopes: Scopes
+    secrets: Secrets
+    userData: UserData
+    utility: Utility
+  Properties:
+    capacity:
+      IS_REQUIRED: true
+      PROPERTY_NAME: capacity
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/capacity
+      TYPE_NAME: Capacity
+      description: |
+        This number represents the number of tasks that this instance type
+        is capable of running concurrently.  This is used by the provisioner
+        to know how many pending tasks to offset a pending instance of this
+        type by
+      type: number
+    instanceType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      description: |
+        InstanceType name for Amazon.
+      type: string
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec
+      description: |
+        LaunchSpecification entries unique to this InstanceType
+      type: object
+    scopes:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scopes
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/scopes
+      TYPE_NAME: Scopes
+      description: |
+        Scopes which should be included for this InstanceType.  Scopes must
+        be composed of printable ASCII characters and spaces.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: scopes entry
+        SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/scopes/items
+        TYPE_NAME: ScopesEntry
+        pattern: ^[ -~]*$
+        type: string
+      type: array
+    secrets:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/secrets
+      TYPE_NAME: Secrets
+      description: |
+        Static Secrets unique to this InstanceType
+      type: object
+    userData:
+      IS_REQUIRED: true
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/userData
+      TYPE_NAME: UserData
+      description: |
+        UserData entries unique to this InstanceType
+      type: object
+    utility:
+      IS_REQUIRED: true
+      PROPERTY_NAME: utility
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/utility
+      TYPE_NAME: Utility
+      description: |
+        This number is a relative measure of performance between two instance
+        types.  It is multiplied by the spot price from Amazon to figure out
+        which instance type is the cheapest one
+      type: number
+  SortedPropertyNames:
+  - capacity
+  - instanceType
+  - launchSpec
+  - scopes
+  - secrets
+  - userData
+  - utility
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties
+required:
+- instanceType
+- capacity
+- utility
+- launchSpec
+- secrets
+- userData
+- scopes
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items
+===========================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: regions entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items
+TYPE_NAME: RegionsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Region configuration
+properties:
+  MemberNames:
+    launchSpec: LaunchSpec
+    region: Region
+    scopes: Scopes
+    secrets: Secrets
+    userData: UserData
+  Properties:
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec
+      additionalProperties:
+        Boolean: true
+        Properties: null
+      description: |
+        LaunchSpecification entries unique to this Region
+      properties:
+        MemberNames:
+          ImageId: ImageID
+        Properties:
+          ImageId:
+            IS_REQUIRED: true
+            PROPERTY_NAME: ImageId
+            SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+            TYPE_NAME: ImageID
+            description: Per-region AMI ImageId
+            type: string
+        SortedPropertyNames:
+        - ImageId
+        SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties
+      required:
+      - ImageId
+      type: object
+    region:
+      IS_REQUIRED: true
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/region
+      TYPE_NAME: Region
+      description: |
+        The Amazon AWS Region being configured.  Example: us-west-1
+      enum:
+      - us-west-2
+      - us-east-1
+      - us-east-2
+      - us-west-1
+      - eu-central-1
+      type: string
+    scopes:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scopes
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/scopes
+      TYPE_NAME: Scopes
+      description: |
+        Scopes which should be included for this Region.  Scopes must be
+        composed of printable ASCII characters and spaces.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: scopes entry
+        SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/scopes/items
+        TYPE_NAME: ScopesEntry
+        pattern: ^[ -~]*$
+        type: string
+      type: array
+    secrets:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/secrets
+      TYPE_NAME: Secrets
+      description: |
+        Static Secrets unique to this Region
+      type: object
+    userData:
+      IS_REQUIRED: true
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/userData
+      TYPE_NAME: UserData
+      description: |
+        UserData entries unique to this Region
+      type: object
+  SortedPropertyNames:
+  - launchSpec
+  - region
+  - scopes
+  - secrets
+  - userData
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties
+required:
+- region
+- launchSpec
+- secrets
+- userData
+- scopes
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
+=================================================================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: launchSpec
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
+TYPE_NAME: LaunchSpec
+additionalProperties:
+  Boolean: true
+  Properties: null
+description: |
+  LaunchSpecification entries unique to this Region
+properties:
+  MemberNames:
+    ImageId: ImageID
+  Properties:
+    ImageId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: ImageId
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+      TYPE_NAME: ImageID
+      description: Per-region AMI ImageId
+      type: string
+  SortedPropertyNames:
+  - ImageId
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties
+required:
+- ImageId
+type: object
+
+
 http://schemas.taskcluster.net/aws-provisioner/v1/get-launch-specs-response.json#
 =================================================================================
 $schema: http://json-schema.org/draft-04/schema#
@@ -4013,6 +4443,53 @@ title: Get Secret Response
 type: object
 
 
+http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials
+==================================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials
+TYPE_NAME: Credentials
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Generated Temporary credentials from the Provisioner
+properties:
+  MemberNames:
+    accessToken: AccessToken
+    certificate: Certificate
+    clientId: ClientID
+  Properties:
+    accessToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessToken
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/accessToken
+      TYPE_NAME: AccessToken
+      type: string
+    certificate:
+      IS_REQUIRED: true
+      PROPERTY_NAME: certificate
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/certificate
+      TYPE_NAME: Certificate
+      type: string
+    clientId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: clientId
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/clientId
+      TYPE_NAME: ClientID
+      type: string
+  SortedPropertyNames:
+  - accessToken
+  - certificate
+  - clientId
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties
+required:
+- clientId
+- accessToken
+- certificate
+type: object
+
+
 http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-last-modified.json#
 =====================================================================================
 $schema: http://json-schema.org/draft-04/schema#
@@ -4104,7 +4581,7 @@ properties:
         IS_REQUIRED: false
         PROPERTY_NAME: availabilityZones entry
         SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items
-        TYPE_NAME: AvailabilityZonesEntry
+        TYPE_NAME: AvailabilityZonesEntry1
         additionalProperties:
           Boolean: false
           Properties: null
@@ -4207,7 +4684,7 @@ properties:
         IS_REQUIRED: false
         PROPERTY_NAME: instanceTypes entry
         SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items
-        TYPE_NAME: InstanceTypesEntry
+        TYPE_NAME: InstanceTypesEntry1
         additionalProperties:
           Boolean: false
           Properties: null
@@ -4385,7 +4862,7 @@ properties:
         IS_REQUIRED: false
         PROPERTY_NAME: regions entry
         SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items
-        TYPE_NAME: RegionsEntry
+        TYPE_NAME: RegionsEntry1
         additionalProperties:
           Boolean: false
           Properties: null
@@ -4402,7 +4879,7 @@ properties:
               IS_REQUIRED: true
               PROPERTY_NAME: launchSpec
               SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
-              TYPE_NAME: LaunchSpec
+              TYPE_NAME: LaunchSpec1
               additionalProperties:
                 Boolean: true
                 Properties: null
@@ -4575,6 +5052,320 @@ required:
 - description
 - owner
 title: Get Worker Type Response
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items
+===================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: availabilityZones entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items
+TYPE_NAME: AvailabilityZonesEntry1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Availability zone configuration
+properties:
+  MemberNames:
+    availabilityZone: AvailabilityZone
+    launchSpec: LaunchSpec
+    region: Region
+    secrets: Secrets
+    userData: UserData
+  Properties:
+    availabilityZone:
+      IS_REQUIRED: true
+      PROPERTY_NAME: availabilityZone
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/availabilityZone
+      TYPE_NAME: AvailabilityZone
+      description: |
+        The AWS availability zone being configured.  Example: eu-central-1b
+      type: string
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec
+      description: |
+        LaunchSpecification entries unique to this AZ
+      type: object
+    region:
+      IS_REQUIRED: true
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/region
+      TYPE_NAME: Region
+      description: |
+        The AWS region containing this availability zone.  Example: eu-central-1
+      type: string
+    secrets:
+      IS_REQUIRED: false
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/secrets
+      TYPE_NAME: Secrets
+      default: {}
+      description: |
+        Static Secrets unique to this AZ
+      type: object
+    userData:
+      IS_REQUIRED: false
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/userData
+      TYPE_NAME: UserData
+      default: {}
+      description: |
+        UserData entries unique to this AZ
+      type: object
+  SortedPropertyNames:
+  - availabilityZone
+  - launchSpec
+  - region
+  - secrets
+  - userData
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties
+required:
+- availabilityZone
+- region
+- launchSpec
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items
+===============================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: instanceTypes entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items
+TYPE_NAME: InstanceTypesEntry1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Instance Type configuration
+properties:
+  MemberNames:
+    capacity: Capacity
+    instanceType: InstanceType
+    launchSpec: LaunchSpec
+    scopes: Scopes
+    secrets: Secrets
+    userData: UserData
+    utility: Utility
+  Properties:
+    capacity:
+      IS_REQUIRED: true
+      PROPERTY_NAME: capacity
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/capacity
+      TYPE_NAME: Capacity
+      description: |
+        This number represents the number of tasks that this instance type
+        is capable of running concurrently.  This is used by the provisioner
+        to know how many pending tasks to offset a pending instance of this
+        type by
+      type: number
+    instanceType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      description: |
+        InstanceType name for Amazon.
+      type: string
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec
+      description: |
+        LaunchSpecification entries unique to this InstanceType
+      type: object
+    scopes:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scopes
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/scopes
+      TYPE_NAME: Scopes
+      description: |
+        Scopes which should be included for this InstanceType.  Scopes must
+        be composed of printable ASCII characters and spaces.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: scopes entry
+        SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/scopes/items
+        TYPE_NAME: ScopesEntry
+        pattern: ^[ -~]*$
+        type: string
+      type: array
+    secrets:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/secrets
+      TYPE_NAME: Secrets
+      description: |
+        Static Secrets unique to this InstanceType
+      type: object
+    userData:
+      IS_REQUIRED: true
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/userData
+      TYPE_NAME: UserData
+      description: |
+        UserData entries unique to this InstanceType
+      type: object
+    utility:
+      IS_REQUIRED: true
+      PROPERTY_NAME: utility
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/utility
+      TYPE_NAME: Utility
+      description: |
+        This number is a relative measure of performance between two instance
+        types.  It is multiplied by the spot price from Amazon to figure out
+        which instance type is the cheapest one
+      type: number
+  SortedPropertyNames:
+  - capacity
+  - instanceType
+  - launchSpec
+  - scopes
+  - secrets
+  - userData
+  - utility
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties
+required:
+- instanceType
+- capacity
+- utility
+- launchSpec
+- secrets
+- userData
+- scopes
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items
+=========================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: regions entry
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items
+TYPE_NAME: RegionsEntry1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: Region configuration
+properties:
+  MemberNames:
+    launchSpec: LaunchSpec
+    region: Region
+    scopes: Scopes
+    secrets: Secrets
+    userData: UserData
+  Properties:
+    launchSpec:
+      IS_REQUIRED: true
+      PROPERTY_NAME: launchSpec
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
+      TYPE_NAME: LaunchSpec1
+      additionalProperties:
+        Boolean: true
+        Properties: null
+      description: |
+        LaunchSpecification entries unique to this Region
+      properties:
+        MemberNames:
+          ImageId: ImageID
+        Properties:
+          ImageId:
+            IS_REQUIRED: true
+            PROPERTY_NAME: ImageId
+            SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+            TYPE_NAME: ImageID
+            description: Per-region AMI ImageId
+            type: string
+        SortedPropertyNames:
+        - ImageId
+        SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties
+      required:
+      - ImageId
+      type: object
+    region:
+      IS_REQUIRED: true
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/region
+      TYPE_NAME: Region
+      description: |
+        The Amazon AWS Region being configured.  Example: us-west-1
+      type: string
+    scopes:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scopes
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/scopes
+      TYPE_NAME: Scopes
+      description: |
+        Scopes which should be included for this Region.  Scopes must be
+        composed of printable ASCII characters and spaces.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: scopes entry
+        SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/scopes/items
+        TYPE_NAME: ScopesEntry
+        pattern: ^[ -~]*$
+        type: string
+      type: array
+    secrets:
+      IS_REQUIRED: true
+      PROPERTY_NAME: secrets
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/secrets
+      TYPE_NAME: Secrets
+      description: |
+        Static Secrets unique to this Region
+      type: object
+    userData:
+      IS_REQUIRED: true
+      PROPERTY_NAME: userData
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/userData
+      TYPE_NAME: UserData
+      description: |
+        UserData entries unique to this Region
+      type: object
+  SortedPropertyNames:
+  - launchSpec
+  - region
+  - scopes
+  - secrets
+  - userData
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties
+required:
+- region
+- launchSpec
+- secrets
+- userData
+- scopes
+type: object
+
+
+http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
+===============================================================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: launchSpec
+SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
+TYPE_NAME: LaunchSpec1
+additionalProperties:
+  Boolean: true
+  Properties: null
+description: |
+  LaunchSpecification entries unique to this Region
+properties:
+  MemberNames:
+    ImageId: ImageID
+  Properties:
+    ImageId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: ImageId
+      SOURCE_URL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+      TYPE_NAME: ImageID
+      description: Per-region AMI ImageId
+      type: string
+  SortedPropertyNames:
+  - ImageId
+  SourceURL: http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties
+required:
+- ImageId
 type: object
 
 
@@ -5220,6 +6011,146 @@ properties:
 required:
 - builds
 title: Builds
+type: object
+
+
+http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items
+=================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: builds entry
+SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items
+TYPE_NAME: BuildsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    created: Created
+    eventId: EventID
+    eventType: EventType
+    organization: Organization
+    repository: Repository
+    sha: Sha
+    state: State
+    taskGroupId: TaskGroupID
+    updated: Updated
+  Properties:
+    created:
+      IS_REQUIRED: true
+      PROPERTY_NAME: created
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/created
+      TYPE_NAME: Created
+      description: |
+        The initial creation time of the build. This is when it became pending.
+      format: date-time
+      type: string
+    eventId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: eventId
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId
+      TYPE_NAME: EventID
+      description: |
+        The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+      oneOf:
+        Items:
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId/oneOf[0]
+          TYPE_NAME: Var
+          pattern: ^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId/oneOf[1]
+          TYPE_NAME: Var1
+          pattern: Unknown
+        SourceURL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId/oneOf
+      type: string
+    eventType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: eventType
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventType
+      TYPE_NAME: EventType
+      description: Type of Github event that triggered the build (i.e. push, pull_request.opened).
+      type: string
+    organization:
+      IS_REQUIRED: true
+      PROPERTY_NAME: organization
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/organization
+      TYPE_NAME: Organization
+      description: Github organization associated with the build.
+      maxLength: 100
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_%]*)$
+      type: string
+    repository:
+      IS_REQUIRED: true
+      PROPERTY_NAME: repository
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/repository
+      TYPE_NAME: Repository
+      description: Github repository associated with the build.
+      maxLength: 100
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_%]*)$
+      type: string
+    sha:
+      IS_REQUIRED: true
+      PROPERTY_NAME: sha
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/sha
+      TYPE_NAME: Sha
+      description: Github revision associated with the build.
+      maxLength: 40
+      minLength: 40
+      type: string
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/state
+      TYPE_NAME: State
+      description: Github status associated with the build.
+      enum:
+      - pending
+      - success
+      - error
+      - failure
+      type: string
+    taskGroupId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskGroupId
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/taskGroupId
+      TYPE_NAME: TaskGroupID
+      description: Taskcluster task-group associated with the build.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      type: string
+    updated:
+      IS_REQUIRED: true
+      PROPERTY_NAME: updated
+      SOURCE_URL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/updated
+      TYPE_NAME: Updated
+      description: |
+        The last updated of the build. If it is done, this is when it finished.
+      format: date-time
+      type: string
+  SortedPropertyNames:
+  - created
+  - eventId
+  - eventType
+  - organization
+  - repository
+  - sha
+  - state
+  - taskGroupId
+  - updated
+  SourceURL: http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties
+required:
+- organization
+- repository
+- sha
+- state
+- taskGroupId
+- eventType
+- eventId
+- created
+- updated
 type: object
 
 
@@ -6079,7 +7010,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: metadata
       SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata
-      TYPE_NAME: Metadata
+      TYPE_NAME: Metadata1
       additionalProperties:
         Boolean: false
         Properties: null
@@ -6195,6 +7126,71 @@ required:
 - metadata
 - task
 title: Hook creation request
+type: object
+
+
+http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata
+=====================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: metadata
+SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata
+TYPE_NAME: Metadata1
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    description: Description
+    emailOnError: EmailOnError
+    name: Name
+    owner: Owner
+  Properties:
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/description
+      TYPE_NAME: Description
+      description: Long-form of the hook's purpose and behavior
+      maxLength: 32768
+      title: Description
+      type: string
+    emailOnError:
+      IS_REQUIRED: false
+      PROPERTY_NAME: emailOnError
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/emailOnError
+      TYPE_NAME: EmailOnError
+      default: true
+      description: Whether to email the owner on an error creating the task.
+      title: Email on error
+      type: boolean
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/name
+      TYPE_NAME: Name
+      description: Human readable name of the hook
+      maxLength: 255
+      title: Name
+      type: string
+    owner:
+      IS_REQUIRED: true
+      PROPERTY_NAME: owner
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/owner
+      TYPE_NAME: Owner
+      description: Email of the person or group responsible for this hook.
+      maxLength: 255
+      title: Owner
+      type: string
+  SortedPropertyNames:
+  - description
+  - emailOnError
+  - name
+  - owner
+  SourceURL: http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties
+required:
+- name
+- description
+- owner
 type: object
 
 
@@ -6368,6 +7364,71 @@ required:
 - deadline
 - triggerSchema
 title: Hook definition
+type: object
+
+
+http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata
+=================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: metadata
+SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata
+TYPE_NAME: Metadata
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    description: Description
+    emailOnError: EmailOnError
+    name: Name
+    owner: Owner
+  Properties:
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/description
+      TYPE_NAME: Description
+      description: Long-form of the hook's purpose and behavior
+      maxLength: 32768
+      title: Description
+      type: string
+    emailOnError:
+      IS_REQUIRED: false
+      PROPERTY_NAME: emailOnError
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/emailOnError
+      TYPE_NAME: EmailOnError
+      default: true
+      description: Whether to email the owner on an error creating the task.
+      title: Email on error
+      type: boolean
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/name
+      TYPE_NAME: Name
+      description: Human readable name of the hook
+      maxLength: 255
+      title: Name
+      type: string
+    owner:
+      IS_REQUIRED: true
+      PROPERTY_NAME: owner
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/owner
+      TYPE_NAME: Owner
+      description: Email of the person or group responsible for this hook.
+      maxLength: 255
+      title: Owner
+      type: string
+  SortedPropertyNames:
+  - description
+  - emailOnError
+  - name
+  - owner
+  SourceURL: http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties
+required:
+- name
+- description
+- owner
 type: object
 
 
@@ -7412,6 +8473,540 @@ title: Task Status Structure
 type: object
 
 
+http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status
+===========================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: status
+SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status
+TYPE_NAME: Status
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    deadline: Deadline
+    expires: Expires
+    provisionerId: ProvisionerID
+    retriesLeft: RetriesLeft
+    runs: Runs
+    schedulerId: SchedulerID
+    state: State
+    taskGroupId: TaskGroupID
+    taskId: TaskID
+    workerType: WorkerType
+  Properties:
+    deadline:
+      IS_REQUIRED: true
+      PROPERTY_NAME: deadline
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/deadline
+      TYPE_NAME: Deadline
+      default: 1 day
+      description: |
+        Use of this field is deprecated; use `deadline: {$fromNow: ..}` in the task template instead.
+      title: Deadline
+      type: string
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/expires
+      TYPE_NAME: Expiration
+      default: 3 months
+      description: |
+        Use of this field is deprecated; use `expires: {$fromNow: ..}` in the task template instead.
+      title: Expiration
+      type: string
+    provisionerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: provisionerId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/provisionerId
+      TYPE_NAME: ProvisionerID
+      description: |
+        Unique identifier for the provisioner that this task must be scheduled on
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Provisioner Id
+      type: string
+    retriesLeft:
+      IS_REQUIRED: true
+      PROPERTY_NAME: retriesLeft
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/retriesLeft
+      TYPE_NAME: RetriesLeft
+      description: |
+        Number of retries left for the task in case of infrastructure issues
+      maximum: 999
+      minimum: 0
+      title: Retries Left
+      type: integer
+    runs:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runs
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs
+      TYPE_NAME: ListOfRuns
+      description: |
+        List of runs, ordered so that index `i` has `runId == i`
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: runs entry
+        SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items
+        TYPE_NAME: RunInformation
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          JSON object with information about a run
+        properties:
+          MemberNames:
+            reasonCreated: ReasonCreated
+            reasonResolved: ReasonResolved
+            resolved: Resolved
+            runId: RunID
+            scheduled: Scheduled
+            started: Started
+            state: State
+            takenUntil: TakenUntil
+            workerGroup: WorkerGroup
+            workerId: WorkerID
+          Properties:
+            reasonCreated:
+              IS_REQUIRED: true
+              PROPERTY_NAME: reasonCreated
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonCreated
+              TYPE_NAME: ReasonCreated
+              description: |
+                Reason for the creation of this run,
+                **more reasons may be added in the future**.
+              enum:
+              - scheduled
+              - retry
+              - task-retry
+              - rerun
+              - exception
+              title: Reason Created
+              type: string
+            reasonResolved:
+              IS_REQUIRED: false
+              PROPERTY_NAME: reasonResolved
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonResolved
+              TYPE_NAME: ReasonResolved
+              description: |
+                Reason that run was resolved, this is mainly
+                useful for runs resolved as `exception`.
+                Note, **more reasons may be added in the future**, also this
+                property is only available after the run is resolved.
+              enum:
+              - completed
+              - failed
+              - deadline-exceeded
+              - canceled
+              - superseded
+              - claim-expired
+              - worker-shutdown
+              - malformed-payload
+              - resource-unavailable
+              - internal-error
+              - intermittent-task
+              title: Reason Resolved
+              type: string
+            resolved:
+              IS_REQUIRED: false
+              PROPERTY_NAME: resolved
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/resolved
+              TYPE_NAME: Resolved
+              description: |
+                Date-time at which this run was resolved, ie. when the run changed
+                state from `running` to either `completed`, `failed` or `exception`.
+                This property is only present after the run as been resolved.
+              format: date-time
+              title: Resolved
+              type: string
+            runId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: runId
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/runId
+              TYPE_NAME: RunIdentifier
+              description: |
+                Id of this task run, `run-id`s always starts from `0`
+              maximum: 1000
+              minimum: 0
+              title: Run Identifier
+              type: integer
+            scheduled:
+              IS_REQUIRED: true
+              PROPERTY_NAME: scheduled
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/scheduled
+              TYPE_NAME: Scheduled
+              description: |
+                Date-time at which this run was scheduled, ie. when the run was
+                created in state `pending`.
+              format: date-time
+              title: Scheduled
+              type: string
+            started:
+              IS_REQUIRED: false
+              PROPERTY_NAME: started
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/started
+              TYPE_NAME: Started
+              description: |
+                Date-time at which this run was claimed, ie. when the run changed
+                state from `pending` to `running`. This property is only present
+                after the run has been claimed.
+              format: date-time
+              title: Started
+              type: string
+            state:
+              IS_REQUIRED: true
+              PROPERTY_NAME: state
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/state
+              TYPE_NAME: RunState
+              description: |
+                State of this run
+              enum:
+              - pending
+              - running
+              - completed
+              - failed
+              - exception
+              title: Run State
+              type: string
+            takenUntil:
+              IS_REQUIRED: false
+              PROPERTY_NAME: takenUntil
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/takenUntil
+              TYPE_NAME: TakenUntil
+              description: |
+                Time at which the run expires and is resolved as `failed`, if the
+                run isn't reclaimed. Note, only present after the run has been
+                claimed.
+              format: date-time
+              title: Taken Until
+              type: string
+            workerGroup:
+              IS_REQUIRED: false
+              PROPERTY_NAME: workerGroup
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerGroup
+              TYPE_NAME: WorkerGroup
+              description: |
+                Identifier for group that worker who executes this run is a part of,
+                this identifier is mainly used for efficient routing.
+                Note, this property is only present after the run is claimed.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Group
+              type: string
+            workerId:
+              IS_REQUIRED: false
+              PROPERTY_NAME: workerId
+              SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerId
+              TYPE_NAME: WorkerIdentifier
+              description: |
+                Identifier for worker evaluating this run within given
+                `workerGroup`. Note, this property is only available after the run
+                has been claimed.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Identifier
+              type: string
+          SortedPropertyNames:
+          - reasonCreated
+          - reasonResolved
+          - resolved
+          - runId
+          - scheduled
+          - started
+          - state
+          - takenUntil
+          - workerGroup
+          - workerId
+          SourceURL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties
+        required:
+        - runId
+        - state
+        - reasonCreated
+        - scheduled
+        title: Run Information
+        type: object
+      title: List of Runs
+      type: array
+    schedulerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: schedulerId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/schedulerId
+      TYPE_NAME: SchedulerIdentifier
+      description: |
+        Identifier for the scheduler that _defined_ this task.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Scheduler Identifier
+      type: string
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/state
+      TYPE_NAME: State
+      description: |
+        State of this task. This is just an auxiliary property derived from state
+        of latests run, or `unscheduled` if none.
+      enum:
+      - unscheduled
+      - pending
+      - running
+      - completed
+      - failed
+      - exception
+      title: State
+      type: string
+    taskGroupId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskGroupId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskGroupId
+      TYPE_NAME: TaskGroupIdentifier
+      description: |
+        Identifier for a group of tasks scheduled together with this task, by
+        scheduler identified by `schedulerId`. For tasks scheduled by the
+        task-graph scheduler, this is the `taskGraphId`.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      title: Task-Group Identifier
+      type: string
+    taskId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskId
+      TYPE_NAME: TaskIdentifier
+      description: |
+        Unique task identifier, this is UUID encoded as
+        [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+        stripped of `=` padding.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      title: Task Identifier
+      type: string
+    workerType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerType
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/workerType
+      TYPE_NAME: WorkerType
+      description: |
+        Identifier for worker type within the specified provisioner
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Type
+      type: string
+  SortedPropertyNames:
+  - deadline
+  - expires
+  - provisionerId
+  - retriesLeft
+  - runs
+  - schedulerId
+  - state
+  - taskGroupId
+  - taskId
+  - workerType
+  SourceURL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties
+required:
+- taskId
+- provisionerId
+- workerType
+- schedulerId
+- taskGroupId
+- deadline
+- expires
+- retriesLeft
+- state
+- runs
+type: object
+
+
+http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items
+=================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: runs entry
+SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items
+TYPE_NAME: RunInformation
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  JSON object with information about a run
+properties:
+  MemberNames:
+    reasonCreated: ReasonCreated
+    reasonResolved: ReasonResolved
+    resolved: Resolved
+    runId: RunID
+    scheduled: Scheduled
+    started: Started
+    state: State
+    takenUntil: TakenUntil
+    workerGroup: WorkerGroup
+    workerId: WorkerID
+  Properties:
+    reasonCreated:
+      IS_REQUIRED: true
+      PROPERTY_NAME: reasonCreated
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonCreated
+      TYPE_NAME: ReasonCreated
+      description: |
+        Reason for the creation of this run,
+        **more reasons may be added in the future**.
+      enum:
+      - scheduled
+      - retry
+      - task-retry
+      - rerun
+      - exception
+      title: Reason Created
+      type: string
+    reasonResolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: reasonResolved
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonResolved
+      TYPE_NAME: ReasonResolved
+      description: |
+        Reason that run was resolved, this is mainly
+        useful for runs resolved as `exception`.
+        Note, **more reasons may be added in the future**, also this
+        property is only available after the run is resolved.
+      enum:
+      - completed
+      - failed
+      - deadline-exceeded
+      - canceled
+      - superseded
+      - claim-expired
+      - worker-shutdown
+      - malformed-payload
+      - resource-unavailable
+      - internal-error
+      - intermittent-task
+      title: Reason Resolved
+      type: string
+    resolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: resolved
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/resolved
+      TYPE_NAME: Resolved
+      description: |
+        Date-time at which this run was resolved, ie. when the run changed
+        state from `running` to either `completed`, `failed` or `exception`.
+        This property is only present after the run as been resolved.
+      format: date-time
+      title: Resolved
+      type: string
+    runId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/runId
+      TYPE_NAME: RunIdentifier
+      description: |
+        Id of this task run, `run-id`s always starts from `0`
+      maximum: 1000
+      minimum: 0
+      title: Run Identifier
+      type: integer
+    scheduled:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scheduled
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/scheduled
+      TYPE_NAME: Scheduled
+      description: |
+        Date-time at which this run was scheduled, ie. when the run was
+        created in state `pending`.
+      format: date-time
+      title: Scheduled
+      type: string
+    started:
+      IS_REQUIRED: false
+      PROPERTY_NAME: started
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/started
+      TYPE_NAME: Started
+      description: |
+        Date-time at which this run was claimed, ie. when the run changed
+        state from `pending` to `running`. This property is only present
+        after the run has been claimed.
+      format: date-time
+      title: Started
+      type: string
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/state
+      TYPE_NAME: RunState
+      description: |
+        State of this run
+      enum:
+      - pending
+      - running
+      - completed
+      - failed
+      - exception
+      title: Run State
+      type: string
+    takenUntil:
+      IS_REQUIRED: false
+      PROPERTY_NAME: takenUntil
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/takenUntil
+      TYPE_NAME: TakenUntil
+      description: |
+        Time at which the run expires and is resolved as `failed`, if the
+        run isn't reclaimed. Note, only present after the run has been
+        claimed.
+      format: date-time
+      title: Taken Until
+      type: string
+    workerGroup:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerGroup
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerGroup
+      TYPE_NAME: WorkerGroup
+      description: |
+        Identifier for group that worker who executes this run is a part of,
+        this identifier is mainly used for efficient routing.
+        Note, this property is only present after the run is claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Group
+      type: string
+    workerId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerId
+      SOURCE_URL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerId
+      TYPE_NAME: WorkerIdentifier
+      description: |
+        Identifier for worker evaluating this run within given
+        `workerGroup`. Note, this property is only available after the run
+        has been claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Identifier
+      type: string
+  SortedPropertyNames:
+  - reasonCreated
+  - reasonResolved
+  - resolved
+  - runId
+  - scheduled
+  - started
+  - state
+  - takenUntil
+  - workerGroup
+  - workerId
+  SourceURL: http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties
+required:
+- runId
+- state
+- reasonCreated
+- scheduled
+title: Run Information
+type: object
+
+
 http://schemas.taskcluster.net/hooks/v1/trigger-context.json#
 =============================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -7947,6 +9542,67 @@ title: List Namespaces Response
 type: object
 
 
+http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items
+==================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: namespaces entry
+SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items
+TYPE_NAME: Namespace
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Representation of a namespace that contains indexed tasks.
+properties:
+  MemberNames:
+    expires: Expires
+    name: Name
+    namespace: Namespace
+  Properties:
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/expires
+      TYPE_NAME: Expiration
+      description: |
+        Date at which this entry, and by implication all entries below it,
+        expires from the task index.
+      format: date-time
+      title: Expiration
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/name
+      TYPE_NAME: Name
+      description: |
+        Name of namespace within it's parent namespace.
+      title: Name
+      type: string
+    namespace:
+      IS_REQUIRED: true
+      PROPERTY_NAME: namespace
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/namespace
+      TYPE_NAME: Namespace
+      description: |
+        Fully qualified name of the namespace, you can use this to list
+        namespaces or tasks under this namespace.
+      maxLength: 255
+      title: Namespace
+      type: string
+  SortedPropertyNames:
+  - expires
+  - name
+  - namespace
+  SourceURL: http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties
+required:
+- namespace
+- name
+- expires
+title: Namespace
+type: object
+
+
 http://schemas.taskcluster.net/index/v1/list-tasks-response.json#
 =================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -8077,6 +9733,94 @@ properties:
 required:
 - tasks
 title: List Tasks Response
+type: object
+
+
+http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items
+========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: tasks entry
+SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items
+TYPE_NAME: Task
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Representation of a task.
+properties:
+  MemberNames:
+    data: Data
+    expires: Expires
+    namespace: Namespace
+    rank: Rank
+    taskId: TaskID
+  Properties:
+    data:
+      IS_REQUIRED: true
+      PROPERTY_NAME: data
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/data
+      TYPE_NAME: TaskSpecificData
+      description: |
+        Data that was reported with the task. This is an arbitrary JSON
+        object.
+      title: Task Specific Data
+      type: object
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/expires
+      TYPE_NAME: Expiration
+      description: |
+        Date at which this entry expires from the task index.
+      format: date-time
+      title: Expiration
+      type: string
+    namespace:
+      IS_REQUIRED: true
+      PROPERTY_NAME: namespace
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/namespace
+      TYPE_NAME: Namespace
+      description: |
+        Index path of the task.
+      maxLength: 255
+      title: Namespace
+      type: string
+    rank:
+      IS_REQUIRED: true
+      PROPERTY_NAME: rank
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/rank
+      TYPE_NAME: Rank
+      description: |
+        If multiple tasks are indexed with the same `namespace` the task
+        with the highest `rank` will be stored and returned in later
+        requests. If two tasks has the same `rank` the latest task will be
+        stored.
+      title: Rank
+      type: number
+    taskId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskId
+      SOURCE_URL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/taskId
+      TYPE_NAME: TaskIdentifier
+      description: |
+        Unique task identifier for the task currently indexed at `namespace`.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      title: Task Identifier
+      type: string
+  SortedPropertyNames:
+  - data
+  - expires
+  - namespace
+  - rank
+  - taskId
+  SourceURL: http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties
+required:
+- namespace
+- taskId
+- rank
+- data
+- expires
+title: Task
 type: object
 
 
@@ -8216,6 +9960,55 @@ properties:
   - expires
   SourceURL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties
 title: Credentials Response
+type: object
+
+
+http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials
+==============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials
+TYPE_NAME: TaskclusterCredentials
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Taskcluster credentials. Note that the credentials may not contain a certificate!
+properties:
+  MemberNames:
+    accessToken: AccessToken
+    certificate: Certificate
+    clientId: ClientID
+  Properties:
+    accessToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessToken
+      SOURCE_URL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/accessToken
+      TYPE_NAME: AccessToken
+      pattern: ^[a-zA-Z0-9_-]{22,66}$
+      type: string
+    certificate:
+      IS_REQUIRED: false
+      PROPERTY_NAME: certificate
+      SOURCE_URL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/certificate
+      TYPE_NAME: Certificate
+      type: string
+    clientId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: clientId
+      SOURCE_URL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/clientId
+      TYPE_NAME: ClientID
+      pattern: ^[A-Za-z0-9!@/:.+|_-]+$
+      type: string
+  SortedPropertyNames:
+  - accessToken
+  - certificate
+  - clientId
+  SourceURL: http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties
+required:
+- clientId
+- accessToken
+title: Taskcluster Credentials
 type: object
 
 
@@ -8428,6 +10221,53 @@ required:
 - subject
 - content
 title: Send Email Request
+type: object
+
+
+http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link
+============================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: link
+SOURCE_URL: http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link
+TYPE_NAME: Link
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Optional link that can be added as a button to the email.
+properties:
+  MemberNames:
+    href: Href
+    text: Text
+  Properties:
+    href:
+      IS_REQUIRED: true
+      PROPERTY_NAME: href
+      SOURCE_URL: http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/href
+      TYPE_NAME: Href
+      description: |
+        Where the link should point to.
+      format: uri
+      maxLength: 1024
+      minLength: 1
+      type: string
+    text:
+      IS_REQUIRED: true
+      PROPERTY_NAME: text
+      SOURCE_URL: http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/text
+      TYPE_NAME: Text
+      description: |
+        Text to display on link.
+      maxLength: 40
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - href
+  - text
+  SourceURL: http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties
+required:
+- text
+- href
 type: object
 
 
@@ -8751,6 +10591,66 @@ title: Open All Purge Requests List
 type: object
 
 
+http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items
+==========================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: requests entry
+SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items
+TYPE_NAME: RequestsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    before: Before
+    cacheName: CacheName
+    provisionerId: ProvisionerID
+    workerType: WorkerType
+  Properties:
+    before:
+      IS_REQUIRED: true
+      PROPERTY_NAME: before
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/before
+      TYPE_NAME: Before
+      description: |
+        All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
+      format: date-time
+      type: string
+    cacheName:
+      IS_REQUIRED: true
+      PROPERTY_NAME: cacheName
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/cacheName
+      TYPE_NAME: CacheName
+      description: Name of cache to purge.
+      type: string
+    provisionerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: provisionerId
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
+      TYPE_NAME: ProvisionerID
+      description: ProvisionerId associated with the workerType.
+      type: string
+    workerType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerType
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/workerType
+      TYPE_NAME: WorkerType
+      description: Workertype cache exists on.
+      type: string
+  SortedPropertyNames:
+  - before
+  - cacheName
+  - provisionerId
+  - workerType
+  SourceURL: http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties
+required:
+- provisionerId
+- workerType
+- cacheName
+- before
+type: object
+
+
 http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#
 ============================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -8787,7 +10687,7 @@ properties:
         IS_REQUIRED: false
         PROPERTY_NAME: requests entry
         SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items
-        TYPE_NAME: RequestsEntry
+        TYPE_NAME: RequestsEntry1
         additionalProperties:
           Boolean: false
           Properties: null
@@ -8849,6 +10749,66 @@ required:
 - requests
 - cacheHit
 title: Open Purge Request List
+type: object
+
+
+http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items
+======================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: requests entry
+SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items
+TYPE_NAME: RequestsEntry1
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    before: Before
+    cacheName: CacheName
+    provisionerId: ProvisionerID
+    workerType: WorkerType
+  Properties:
+    before:
+      IS_REQUIRED: true
+      PROPERTY_NAME: before
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/before
+      TYPE_NAME: Before
+      description: |
+        All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
+      format: date-time
+      type: string
+    cacheName:
+      IS_REQUIRED: true
+      PROPERTY_NAME: cacheName
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/cacheName
+      TYPE_NAME: CacheName
+      description: Name of cache to purge.
+      type: string
+    provisionerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: provisionerId
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
+      TYPE_NAME: ProvisionerID
+      description: ProvisionerId associated with the workerType.
+      type: string
+    workerType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerType
+      SOURCE_URL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/workerType
+      TYPE_NAME: WorkerType
+      description: Workertype cache exists on.
+      type: string
+  SortedPropertyNames:
+  - before
+  - cacheName
+  - provisionerId
+  - workerType
+  SourceURL: http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties
+required:
+- provisionerId
+- workerType
+- cacheName
+- before
 type: object
 
 
@@ -9845,6 +11805,307 @@ Entry 33    =
     Entry Title       = 'Ping Server'
     Entry Description = 'Respond without doing anything.
 This endpoint is used to check that the service is up.'
+
+
+http://schemas.taskcluster.net/queue/v1/actions.json#
+=====================================================
+$schema: http://json-schema.org/draft-06/schema#
+IS_REQUIRED: false
+PROPERTY_NAME: ""
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#
+TYPE_NAME: Actions3
+description: |
+  See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+id: http://schemas.taskcluster.net/queue/v1/actions.json#
+items:
+  IS_REQUIRED: false
+  PROPERTY_NAME: ' entry'
+  SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+  TYPE_NAME: Actions4
+  additionalProperties:
+    Boolean: false
+    Properties: null
+  description: |
+    Actions provide a generic mechanism to expose additional features of a
+    provisioner, worker type, or worker to Taskcluster clients.
+
+    An action is comprised of metadata describing the feature it exposes,
+    together with a webhook for triggering it.
+
+    The Taskcluster tools site, for example, retrieves actions when displaying
+    provisioners, worker types and workers. It presents the provisioner/worker
+    type/worker specific actions to the user. When the user triggers an action,
+    the web client takes the registered webhook, substitutes parameters into the
+    URL (see `url`), signs the requests with the Taskcluster credentials of the
+    user operating the web interface, and issues the HTTP request.
+
+    The level to which the action relates (provisioner, worker type, worker) is
+    called the action context. All actions, regardless of the action contexts,
+    are registered against the provisioner when calling
+    `queue.declareProvisioner`.
+
+    The action context is used by the web client to determine where in the web
+    interface to present the action to the user as follows:
+
+    | `context`   | Tool where action is displayed |
+    |-------------|--------------------------------|
+    | provisioner | Provisioner Explorer           |
+    | worker-type | Workers Explorer               |
+    | worker      | Worker Explorer                |
+
+    See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+    for more information.
+  properties:
+    MemberNames:
+      context: Context
+      description: Description
+      method: Method
+      name: Name
+      title: Title
+      url: URL
+    Properties:
+      context:
+        IS_REQUIRED: true
+        PROPERTY_NAME: context
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+        TYPE_NAME: Context
+        description: |
+          Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+          which it applies to. `context` is used by the front-end to know where to display the action.
+
+          | `context`   | Page displayed        |
+          |-------------|-----------------------|
+          | provisioner | Provisioner Explorer  |
+          | worker-type | Workers Explorer      |
+          | worker      | Worker Explorer       |
+        enum:
+        - provisioner
+        - worker-type
+        - worker
+        title: Context
+        type: string
+      description:
+        IS_REQUIRED: true
+        PROPERTY_NAME: description
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+        TYPE_NAME: Description
+        description: |
+          Description of the provisioner.
+        title: Description
+        type: string
+      method:
+        IS_REQUIRED: true
+        PROPERTY_NAME: method
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+        TYPE_NAME: Method
+        description: |
+          Method to indicate the desired action to be performed for a given resource.
+        enum:
+        - POST
+        - PUT
+        - DELETE
+        - PATCH
+        title: Method
+        type: string
+      name:
+        IS_REQUIRED: true
+        PROPERTY_NAME: name
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+        TYPE_NAME: Name
+        description: |
+          Short names for things like logging/error messages.
+        title: Name
+        type: string
+      title:
+        IS_REQUIRED: true
+        PROPERTY_NAME: title
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+        TYPE_NAME: Title
+        description: |
+          Appropriate title for any sort of Modal prompt.
+        title: Title
+      url:
+        IS_REQUIRED: true
+        PROPERTY_NAME: url
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+        TYPE_NAME: URL
+        description: |
+          When an action is triggered, a request is made using the `url` and `method`.
+          Depending on the `context`, the following parameters will be substituted in the url:
+
+          | `context`   | Path parameters                                          |
+          |-------------|----------------------------------------------------------|
+          | provisioner | <provisionerId>                                          |
+          | worker-type | <provisionerId>, <workerType>                            |
+          | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+          _Note: The request needs to be signed with the user's Taskcluster credentials._
+        title: URL
+        type: string
+    SortedPropertyNames:
+    - context
+    - description
+    - method
+    - name
+    - title
+    - url
+    SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+  required:
+  - name
+  - title
+  - context
+  - url
+  - method
+  - description
+  title: Actions
+  type: object
+title: Actions
+type: array
+
+
+http://schemas.taskcluster.net/queue/v1/actions.json#/items
+===========================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ' entry'
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+TYPE_NAME: Actions4
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Actions provide a generic mechanism to expose additional features of a
+  provisioner, worker type, or worker to Taskcluster clients.
+
+  An action is comprised of metadata describing the feature it exposes,
+  together with a webhook for triggering it.
+
+  The Taskcluster tools site, for example, retrieves actions when displaying
+  provisioners, worker types and workers. It presents the provisioner/worker
+  type/worker specific actions to the user. When the user triggers an action,
+  the web client takes the registered webhook, substitutes parameters into the
+  URL (see `url`), signs the requests with the Taskcluster credentials of the
+  user operating the web interface, and issues the HTTP request.
+
+  The level to which the action relates (provisioner, worker type, worker) is
+  called the action context. All actions, regardless of the action contexts,
+  are registered against the provisioner when calling
+  `queue.declareProvisioner`.
+
+  The action context is used by the web client to determine where in the web
+  interface to present the action to the user as follows:
+
+  | `context`   | Tool where action is displayed |
+  |-------------|--------------------------------|
+  | provisioner | Provisioner Explorer           |
+  | worker-type | Workers Explorer               |
+  | worker      | Worker Explorer                |
+
+  See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+  for more information.
+properties:
+  MemberNames:
+    context: Context
+    description: Description
+    method: Method
+    name: Name
+    title: Title
+    url: URL
+  Properties:
+    context:
+      IS_REQUIRED: true
+      PROPERTY_NAME: context
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+      TYPE_NAME: Context
+      description: |
+        Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+        which it applies to. `context` is used by the front-end to know where to display the action.
+
+        | `context`   | Page displayed        |
+        |-------------|-----------------------|
+        | provisioner | Provisioner Explorer  |
+        | worker-type | Workers Explorer      |
+        | worker      | Worker Explorer       |
+      enum:
+      - provisioner
+      - worker-type
+      - worker
+      title: Context
+      type: string
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+      TYPE_NAME: Description
+      description: |
+        Description of the provisioner.
+      title: Description
+      type: string
+    method:
+      IS_REQUIRED: true
+      PROPERTY_NAME: method
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+      TYPE_NAME: Method
+      description: |
+        Method to indicate the desired action to be performed for a given resource.
+      enum:
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+      title: Method
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+      TYPE_NAME: Name
+      description: |
+        Short names for things like logging/error messages.
+      title: Name
+      type: string
+    title:
+      IS_REQUIRED: true
+      PROPERTY_NAME: title
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+      TYPE_NAME: Title
+      description: |
+        Appropriate title for any sort of Modal prompt.
+      title: Title
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+      TYPE_NAME: URL
+      description: |
+        When an action is triggered, a request is made using the `url` and `method`.
+        Depending on the `context`, the following parameters will be substituted in the url:
+
+        | `context`   | Path parameters                                          |
+        |-------------|----------------------------------------------------------|
+        | provisioner | <provisionerId>                                          |
+        | worker-type | <provisionerId>, <workerType>                            |
+        | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+        _Note: The request needs to be signed with the user's Taskcluster credentials._
+      title: URL
+      type: string
+  SortedPropertyNames:
+  - context
+  - description
+  - method
+  - name
+  - title
+  - url
+  SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+required:
+- name
+- title
+- context
+- url
+- method
+- description
+title: Actions
+type: object
 
 
 http://schemas.taskcluster.net/queue/v1/claim-work-request.json#
@@ -10872,6 +13133,1005 @@ title: Claim Work Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items
+========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: tasks entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items
+TYPE_NAME: TasksEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    credentials: Credentials
+    runId: RunID
+    status: Status
+    takenUntil: TakenUntil
+    task: Task
+    workerGroup: WorkerGroup
+    workerId: WorkerID
+  Properties:
+    credentials:
+      IS_REQUIRED: true
+      PROPERTY_NAME: credentials
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
+      TYPE_NAME: Credentials
+      additionalProperties:
+        Boolean: false
+        Properties: null
+      description: |
+        Temporary credentials granting `task.scopes` and the scope:
+        `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+        the task, upload artifacts and report task resolution.
+
+        The temporary credentials are set to expire after `takenUntil`. They
+        won't expire exactly at `takenUntil` but shortly after, hence, requests
+        coming close `takenUntil` won't have problems even if there is a little
+        clock drift.
+
+        Workers should use these credentials when making requests on behalf of
+        a task. This includes requests to create artifacts, reclaiming the task
+        reporting the task `completed`, `failed` or `exception`.
+
+        Note, a new set of temporary credentials is issued when the worker
+        reclaims the task.
+      properties:
+        MemberNames:
+          accessToken: AccessToken
+          certificate: Certificate
+          clientId: ClientID
+        Properties:
+          accessToken:
+            IS_REQUIRED: true
+            PROPERTY_NAME: accessToken
+            SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/accessToken
+            TYPE_NAME: AccessToken
+            description: |
+              The `accessToken` for the temporary credentials.
+            minLength: 1
+            type: string
+          certificate:
+            IS_REQUIRED: true
+            PROPERTY_NAME: certificate
+            SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/certificate
+            TYPE_NAME: Certificate
+            description: |
+              The `certificate` for the temporary credentials, these are required
+              for the temporary credentials to work.
+            minLength: 1
+            type: string
+          clientId:
+            IS_REQUIRED: true
+            PROPERTY_NAME: clientId
+            SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/clientId
+            TYPE_NAME: ClientID
+            description: |
+              The `clientId` for the temporary credentials.
+            minLength: 1
+            type: string
+        SortedPropertyNames:
+        - accessToken
+        - certificate
+        - clientId
+        SourceURL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties
+      required:
+      - clientId
+      - accessToken
+      - certificate
+      type: object
+    runId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/runId
+      TYPE_NAME: RunID
+      description: |
+        `run-id` assigned to this run of the task
+      maximum: 1000
+      minimum: 0
+      type: integer
+    status:
+      $ref: http://schemas.taskcluster.net/queue/v1/task-status.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: status
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        TYPE_NAME: TaskStatusStructure
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          A representation of **task status** as known by the queue
+        id: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        properties:
+          MemberNames:
+            deadline: Deadline
+            expires: Expires
+            provisionerId: ProvisionerID
+            retriesLeft: RetriesLeft
+            runs: Runs
+            schedulerId: SchedulerID
+            state: State
+            taskGroupId: TaskGroupID
+            taskId: TaskID
+            workerType: WorkerType
+          Properties:
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            expires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and
+                status is deleted. Notice that all artifacts for the task
+                must have an expiration that is no later than this.
+              format: date-time
+              title: Expiration
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for the provisioner that this task must be scheduled on
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            retriesLeft:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retriesLeft
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/retriesLeft
+              TYPE_NAME: RetriesLeft
+              description: |
+                Number of retries left for the task in case of infrastructure issues
+              maximum: 999
+              minimum: 0
+              title: Retries Left
+              type: integer
+            runs:
+              IS_REQUIRED: true
+              PROPERTY_NAME: runs
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs
+              TYPE_NAME: ListOfRuns
+              description: |
+                List of runs, ordered so that index `i` has `runId == i`
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: runs entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+                TYPE_NAME: RunInformation
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                description: |
+                  JSON object with information about a run
+                properties:
+                  MemberNames:
+                    reasonCreated: ReasonCreated
+                    reasonResolved: ReasonResolved
+                    resolved: Resolved
+                    runId: RunID
+                    scheduled: Scheduled
+                    started: Started
+                    state: State
+                    takenUntil: TakenUntil
+                    workerGroup: WorkerGroup
+                    workerId: WorkerID
+                  Properties:
+                    reasonCreated:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: reasonCreated
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+                      TYPE_NAME: ReasonCreated
+                      description: |
+                        Reason for the creation of this run,
+                        **more reasons may be added in the future**.
+                      enum:
+                      - scheduled
+                      - retry
+                      - task-retry
+                      - rerun
+                      - exception
+                      title: Reason Created
+                      type: string
+                    reasonResolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: reasonResolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+                      TYPE_NAME: ReasonResolved
+                      description: |
+                        Reason that run was resolved, this is mainly
+                        useful for runs resolved as `exception`.
+                        Note, **more reasons may be added in the future**, also this
+                        property is only available after the run is resolved. Some of these
+                        reasons, notably `intermittent-task`, `worker-shutdown`, and
+                        `claim-expired`, will trigger an automatic retry of the task.
+                      enum:
+                      - completed
+                      - failed
+                      - deadline-exceeded
+                      - canceled
+                      - superseded
+                      - claim-expired
+                      - worker-shutdown
+                      - malformed-payload
+                      - resource-unavailable
+                      - internal-error
+                      - intermittent-task
+                      title: Reason Resolved
+                      type: string
+                    resolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: resolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+                      TYPE_NAME: Resolved
+                      description: |
+                        Date-time at which this run was resolved, ie. when the run changed
+                        state from `running` to either `completed`, `failed` or `exception`.
+                        This property is only present after the run as been resolved.
+                      format: date-time
+                      title: Resolved
+                      type: string
+                    runId:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: runId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+                      TYPE_NAME: RunIdentifier
+                      description: |
+                        Id of this task run, `run-id`s always starts from `0`
+                      maximum: 1000
+                      minimum: 0
+                      title: Run Identifier
+                      type: integer
+                    scheduled:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: scheduled
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+                      TYPE_NAME: Scheduled
+                      description: |
+                        Date-time at which this run was scheduled, ie. when the run was
+                        created in state `pending`.
+                      format: date-time
+                      title: Scheduled
+                      type: string
+                    started:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: started
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+                      TYPE_NAME: Started
+                      description: |
+                        Date-time at which this run was claimed, ie. when the run changed
+                        state from `pending` to `running`. This property is only present
+                        after the run has been claimed.
+                      format: date-time
+                      title: Started
+                      type: string
+                    state:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: state
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+                      TYPE_NAME: RunState
+                      description: |
+                        State of this run
+                      enum:
+                      - pending
+                      - running
+                      - completed
+                      - failed
+                      - exception
+                      title: Run State
+                      type: string
+                    takenUntil:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: takenUntil
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+                      TYPE_NAME: TakenUntil
+                      description: |
+                        Time at which the run expires and is resolved as `failed`, if the
+                        run isn't reclaimed. Note, only present after the run has been
+                        claimed.
+                      format: date-time
+                      title: Taken Until
+                      type: string
+                    workerGroup:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerGroup
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+                      TYPE_NAME: WorkerGroup
+                      description: |
+                        Identifier for group that worker who executes this run is a part of,
+                        this identifier is mainly used for efficient routing.
+                        Note, this property is only present after the run is claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Group
+                      type: string
+                    workerId:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+                      TYPE_NAME: WorkerIdentifier
+                      description: |
+                        Identifier for worker evaluating this run within given
+                        `workerGroup`. Note, this property is only available after the run
+                        has been claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Identifier
+                      type: string
+                  SortedPropertyNames:
+                  - reasonCreated
+                  - reasonResolved
+                  - resolved
+                  - runId
+                  - scheduled
+                  - started
+                  - state
+                  - takenUntil
+                  - workerGroup
+                  - workerId
+                  SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties
+                required:
+                - runId
+                - state
+                - reasonCreated
+                - scheduled
+                title: Run Information
+                type: object
+              title: List of Runs
+              type: array
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            state:
+              IS_REQUIRED: true
+              PROPERTY_NAME: state
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/state
+              TYPE_NAME: State
+              description: |
+                State of this task. This is just an auxiliary property derived from state
+                of latests run, or `unscheduled` if none.
+              enum:
+              - unscheduled
+              - pending
+              - running
+              - completed
+              - failed
+              - exception
+              title: State
+              type: string
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            taskId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskId
+              TYPE_NAME: TaskIdentifier
+              description: |
+                Unique task identifier, this is UUID encoded as
+                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+                stripped of `=` padding.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Identifier for worker type within the specified provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - deadline
+          - expires
+          - provisionerId
+          - retriesLeft
+          - runs
+          - schedulerId
+          - state
+          - taskGroupId
+          - taskId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties
+        required:
+        - taskId
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - deadline
+        - expires
+        - retriesLeft
+        - state
+        - runs
+        title: Task Status Structure
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/status
+      TYPE_NAME: Status
+    takenUntil:
+      IS_REQUIRED: true
+      PROPERTY_NAME: takenUntil
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/takenUntil
+      TYPE_NAME: TakenUntil
+      description: |
+        Time at which the run expires and is resolved as `exception`,
+        with reason `claim-expired` if the run haven't been reclaimed.
+      format: date-time
+      type: string
+    task:
+      $ref: http://schemas.taskcluster.net/queue/v1/task.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: task
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#
+        TYPE_NAME: TaskDefinitionResponse
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          Definition of a task that can be scheduled
+        id: http://schemas.taskcluster.net/queue/v1/task.json#
+        properties:
+          MemberNames:
+            created: Created
+            deadline: Deadline
+            dependencies: Dependencies
+            expires: Expires
+            extra: Extra
+            metadata: Metadata
+            payload: Payload
+            priority: Priority
+            provisionerId: ProvisionerID
+            requires: Requires
+            retries: Retries
+            routes: Routes
+            schedulerId: SchedulerID
+            scopes: Scopes
+            tags: Tags
+            taskGroupId: TaskGroupID
+            workerType: WorkerType
+          Properties:
+            created:
+              IS_REQUIRED: true
+              PROPERTY_NAME: created
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/created
+              TYPE_NAME: Created
+              description: Creation time of task
+              format: date-time
+              title: Created
+              type: string
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            dependencies:
+              IS_REQUIRED: true
+              PROPERTY_NAME: dependencies
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies
+              TYPE_NAME: TaskDependencies
+              description: |
+                List of dependent tasks. These must either be _completed_ or _resolved_
+                before this task is scheduled. See `requires` for semantics.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: dependencies entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies/items
+                TYPE_NAME: TaskDependency
+                description: |
+                  The `taskId` of a task that must be resolved before this task is
+                  scheduled.
+                pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+                title: Task Dependency
+                type: string
+              maxItems: 100
+              title: Task Dependencies
+              type: array
+              uniqueItems: true
+            expires:
+              IS_REQUIRED: false
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and status is deleted.
+                Notice that all artifacts for the task must have an expiration that is no
+                later than this. If this property isn't it will be set to `deadline`
+                plus one year (this default may subject to change).
+              format: date-time
+              title: Expiration
+              type: string
+            extra:
+              IS_REQUIRED: true
+              PROPERTY_NAME: extra
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/extra
+              TYPE_NAME: ExtraData
+              default: {}
+              description: |
+                Object with properties that can hold any kind of extra data that should be
+                associated with the task. This can be data for the task which doesn't
+                fit into `payload`, or it can supplementary data for use in services
+                listening for events from this task. For example this could be details to
+                display on _treeherder_, or information for indexing the task. Please, try
+                to put all related information under one property, so `extra` data keys
+                for treeherder reporting and task indexing don't conflict, hence, we have
+                reusable services. **Warning**, do not stuff large data-sets in here,
+                task definitions should not take-up multiple MiBs.
+              title: Extra Data
+              type: object
+            metadata:
+              IS_REQUIRED: true
+              PROPERTY_NAME: metadata
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+              TYPE_NAME: MetaData
+              additionalProperties:
+                Boolean: false
+                Properties: null
+              description: |
+                Required task metadata
+              properties:
+                MemberNames:
+                  description: Description
+                  name: Name
+                  owner: Owner
+                  source: Source
+                Properties:
+                  description:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: description
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
+                    TYPE_NAME: Description
+                    description: |
+                      Human readable description of the task, please **explain** what the
+                      task does. A few lines of documentation is not going to hurt you.
+                    maxLength: 32768
+                    title: Description
+                    type: string
+                  name:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: name
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
+                    TYPE_NAME: Name
+                    description: |
+                      Human readable name of task, used to very briefly given an idea about
+                      what the task does.
+                    maxLength: 255
+                    title: Name
+                    type: string
+                  owner:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: owner
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
+                    TYPE_NAME: Owner
+                    description: |
+                      E-mail of person who caused this task, e.g. the person who did
+                      `hg push`. The person we should contact to ask why this task is here.
+                    format: email
+                    maxLength: 255
+                    title: Owner
+                    type: string
+                  source:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: source
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
+                    TYPE_NAME: Source
+                    description: |
+                      Link to source of this task, should specify a file, revision and
+                      repository. This should be place someone can go an do a git/hg blame
+                      to who came up with recipe for this task.
+                    format: uri
+                    maxLength: 4096
+                    pattern: ^https?://
+                    title: Source
+                    type: string
+                SortedPropertyNames:
+                - description
+                - name
+                - owner
+                - source
+                SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties
+              required:
+              - name
+              - description
+              - owner
+              - source
+              title: Meta-data
+              type: object
+            payload:
+              IS_REQUIRED: true
+              PROPERTY_NAME: payload
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/payload
+              TYPE_NAME: TaskPayload
+              description: |
+                Task-specific payload following worker-specific format. For example the
+                `docker-worker` requires keys like: `image`, `commands` and
+                `features`. Refer to the documentation of `docker-worker` for details.
+              title: Task Payload
+              type: object
+            priority:
+              IS_REQUIRED: true
+              PROPERTY_NAME: priority
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/priority
+              TYPE_NAME: TaskPriority
+              description: |
+                Priority of task, this defaults to `lowest` and the scope
+                `queue:create-task:<priority>/<provisionerId>/<workerType>` is required
+                to define a task with `<priority>`.
+              enum:
+              - highest
+              - very-high
+              - high
+              - medium
+              - low
+              - very-low
+              - lowest
+              title: Task Priority
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for a provisioner, that can supply specified
+                `workerType`
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            requires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: requires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/requires
+              TYPE_NAME: DependencyRequirementSemantics
+              description: |
+                The tasks relation to its dependencies. This property specifies the
+                semantics of the `task.dependencies` property.
+                If `all-completed` is given the task will be scheduled when all
+                dependencies are resolved _completed_ (successful resolution).
+                If `all-resolved` is given the task will be scheduled when all dependencies
+                have been resolved, regardless of what their resolution is.
+              enum:
+              - all-completed
+              - all-resolved
+              title: Dependency Requirement Semantics
+              type: string
+            retries:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retries
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/retries
+              TYPE_NAME: Retries
+              description: |
+                Number of times to retry the task in case of infrastructure issues.
+                An _infrastructure issue_ is a worker node that crashes or is shutdown,
+                these events are to be expected.
+              maximum: 49
+              minimum: 0
+              title: Retries
+              type: integer
+            routes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: routes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes
+              TYPE_NAME: TaskSpecificRoutes
+              description: |
+                List of task specific routes, AMQP messages will be CC'ed to these routes.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: routes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes/items
+                TYPE_NAME: TaskSpecificRoute
+                description: |
+                  A task specific route, AMQP messages will be CC'ed with a routing key
+                  matching `route.<task-specific route>`. It's possible to dot (`.`) in
+                  the task specific route to make sub-keys, etc. See the RabbitMQ
+                  [tutorial](http://www.rabbitmq.com/tutorials/tutorial-five-python.html)
+                  for examples on how to use routing-keys.
+                maxLength: 249
+                minLength: 1
+                title: Task Specific Route
+                type: string
+              maxItems: 64
+              title: Task Specific Routes
+              type: array
+              uniqueItems: true
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task, this can be an
+                identifier for a user or a service like the `"task-graph-scheduler"`.
+                Along with the `taskGroupId` this is used to form the permission scope
+                `queue:assume:scheduler-id:<schedulerId>/<taskGroupId>`,
+                this scope is necessary to _schedule_ a defined task, or _rerun_ a task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            scopes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: scopes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes
+              TYPE_NAME: Scopes
+              description: |
+                List of scopes (or scope-patterns) that the task is
+                authorized to use.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: scopes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes/items
+                TYPE_NAME: Scope
+                description: |
+                  A scope (or scope-patterns) which the task is
+                  authorized to use. This can be a string or a string
+                  ending with `*` which will authorize all scopes for
+                  which the string is a prefix.  Scopes must be composed of
+                  printable ASCII characters and spaces.
+                pattern: ^[\x20-\x7e]*$
+                title: Scope
+                type: string
+              title: Scopes
+              type: array
+            tags:
+              IS_REQUIRED: true
+              PROPERTY_NAME: tags
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/tags
+              TYPE_NAME: Tags
+              additionalProperties:
+                Boolean: null
+                Properties:
+                  IS_REQUIRED: false
+                  PROPERTY_NAME: ""
+                  SOURCE_URL: ""
+                  TYPE_NAME: ""
+                  maxLength: 4096
+                  type: string
+              description: |
+                Arbitrary key-value tags (only strings limited to 4k). These can be used
+                to attach informal meta-data to a task. Use this for informal tags that
+                tasks can be classified by. You can also think of strings here as
+                candidates for formal meta-data. Something like
+                `purpose: 'build' || 'test'` is a good example.
+              title: Tags
+              type: object
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.  Defaults to `taskId` if
+                property isn't specified.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Unique identifier for a worker-type within a specific provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - created
+          - deadline
+          - dependencies
+          - expires
+          - extra
+          - metadata
+          - payload
+          - priority
+          - provisionerId
+          - requires
+          - retries
+          - routes
+          - schedulerId
+          - scopes
+          - tags
+          - taskGroupId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties
+        required:
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - dependencies
+        - requires
+        - routes
+        - priority
+        - retries
+        - created
+        - deadline
+        - scopes
+        - payload
+        - metadata
+        - tags
+        - extra
+        title: Task Definition Response
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/task
+      TYPE_NAME: Task
+    workerGroup:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerGroup
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerGroup
+      TYPE_NAME: WorkerGroup
+      description: |
+        Identifier for the worker-group within which this run started.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      type: string
+    workerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerId
+      TYPE_NAME: WorkerID
+      description: |
+        Identifier for the worker executing this run.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      type: string
+  SortedPropertyNames:
+  - credentials
+  - runId
+  - status
+  - takenUntil
+  - task
+  - workerGroup
+  - workerId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties
+required:
+- status
+- runId
+- workerGroup
+- workerId
+- takenUntil
+- task
+- credentials
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
+===============================================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
+TYPE_NAME: Credentials
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Temporary credentials granting `task.scopes` and the scope:
+  `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+  the task, upload artifacts and report task resolution.
+
+  The temporary credentials are set to expire after `takenUntil`. They
+  won't expire exactly at `takenUntil` but shortly after, hence, requests
+  coming close `takenUntil` won't have problems even if there is a little
+  clock drift.
+
+  Workers should use these credentials when making requests on behalf of
+  a task. This includes requests to create artifacts, reclaiming the task
+  reporting the task `completed`, `failed` or `exception`.
+
+  Note, a new set of temporary credentials is issued when the worker
+  reclaims the task.
+properties:
+  MemberNames:
+    accessToken: AccessToken
+    certificate: Certificate
+    clientId: ClientID
+  Properties:
+    accessToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessToken
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/accessToken
+      TYPE_NAME: AccessToken
+      description: |
+        The `accessToken` for the temporary credentials.
+      minLength: 1
+      type: string
+    certificate:
+      IS_REQUIRED: true
+      PROPERTY_NAME: certificate
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/certificate
+      TYPE_NAME: Certificate
+      description: |
+        The `certificate` for the temporary credentials, these are required
+        for the temporary credentials to work.
+      minLength: 1
+      type: string
+    clientId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: clientId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/clientId
+      TYPE_NAME: ClientID
+      description: |
+        The `clientId` for the temporary credentials.
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - accessToken
+  - certificate
+  - clientId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties
+required:
+- clientId
+- accessToken
+- certificate
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/create-task-request.json#
 =================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -10986,7 +14246,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: metadata
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata
-      TYPE_NAME: MetaData
+      TYPE_NAME: MetaData1
       additionalProperties:
         Boolean: false
         Properties: null
@@ -11291,6 +14551,87 @@ title: Task Definition Request
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata
+=====================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: metadata
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata
+TYPE_NAME: MetaData1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Required task metadata
+properties:
+  MemberNames:
+    description: Description
+    name: Name
+    owner: Owner
+    source: Source
+  Properties:
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/description
+      TYPE_NAME: Description
+      description: |
+        Human readable description of the task, please **explain** what the
+        task does. A few lines of documentation is not going to hurt you.
+      maxLength: 32768
+      title: Description
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/name
+      TYPE_NAME: Name
+      description: |
+        Human readable name of task, used to very briefly given an idea about
+        what the task does.
+      maxLength: 255
+      title: Name
+      type: string
+    owner:
+      IS_REQUIRED: true
+      PROPERTY_NAME: owner
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/owner
+      TYPE_NAME: Owner
+      description: |
+        E-mail of person who caused this task, e.g. the person who did
+        `hg push`. The person we should contact to ask why this task is here.
+      format: email
+      maxLength: 255
+      title: Owner
+      type: string
+    source:
+      IS_REQUIRED: true
+      PROPERTY_NAME: source
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/source
+      TYPE_NAME: Source
+      description: |
+        Link to source of this task, should specify a file, revision and
+        repository. This should be place someone can go an do a git/hg blame
+        to who came up with recipe for this task.
+      format: uri
+      maxLength: 4096
+      pattern: ^https?://
+      title: Source
+      type: string
+  SortedPropertyNames:
+  - description
+  - name
+  - owner
+  - source
+  SourceURL: http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties
+required:
+- name
+- description
+- owner
+- source
+title: Meta-data
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#
 =====================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -11421,6 +14762,87 @@ title: List Artifacts Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items
+================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: artifacts entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items
+TYPE_NAME: Artifact
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Information about an artifact for the given `taskId` and `runId`.
+properties:
+  MemberNames:
+    contentType: ContentType
+    expires: Expires
+    name: Name
+    storageType: StorageType
+  Properties:
+    contentType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: contentType
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/contentType
+      TYPE_NAME: ContentType
+      description: |
+        Mimetype for the artifact that was created.
+      maxLength: 255
+      title: Content-Type
+      type: string
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/expires
+      TYPE_NAME: ArtifactExpiration
+      description: |
+        Date and time after which the artifact created will be automatically
+        deleted by the queue.
+      format: date-time
+      title: Artifact Expiration
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/name
+      TYPE_NAME: ArtifactName
+      description: |
+        Name of the artifact that was created, this is useful if you want to
+        attempt to fetch the artifact.
+      maxLength: 1024
+      title: Artifact Name
+      type: string
+    storageType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: storageType
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/storageType
+      TYPE_NAME: ArtifactStorageType
+      description: |
+        This is the `storageType` for the request that was used to create
+        the artifact.
+      enum:
+      - blob
+      - s3
+      - azure
+      - reference
+      - error
+      title: Artifact Storage-Type
+      type: string
+  SortedPropertyNames:
+  - contentType
+  - expires
+  - name
+  - storageType
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties
+required:
+- storageType
+- name
+- expires
+- contentType
+title: Artifact
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#
 ===========================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -11476,7 +14898,7 @@ properties:
         IS_REQUIRED: false
         PROPERTY_NAME: tasks entry
         SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items
-        TYPE_NAME: TaskDefinitionAndStatus
+        TYPE_NAME: TaskDefinitionAndStatus1
         additionalProperties:
           Boolean: false
           Properties: null
@@ -12289,6 +15711,812 @@ title: List Dependent Tasks Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items
+==================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: tasks entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items
+TYPE_NAME: TaskDefinitionAndStatus1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Task Definition and task status structure.
+properties:
+  MemberNames:
+    status: Status
+    task: Task
+  Properties:
+    status:
+      $ref: http://schemas.taskcluster.net/queue/v1/task-status.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: status
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        TYPE_NAME: TaskStatusStructure
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          A representation of **task status** as known by the queue
+        id: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        properties:
+          MemberNames:
+            deadline: Deadline
+            expires: Expires
+            provisionerId: ProvisionerID
+            retriesLeft: RetriesLeft
+            runs: Runs
+            schedulerId: SchedulerID
+            state: State
+            taskGroupId: TaskGroupID
+            taskId: TaskID
+            workerType: WorkerType
+          Properties:
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            expires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and
+                status is deleted. Notice that all artifacts for the task
+                must have an expiration that is no later than this.
+              format: date-time
+              title: Expiration
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for the provisioner that this task must be scheduled on
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            retriesLeft:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retriesLeft
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/retriesLeft
+              TYPE_NAME: RetriesLeft
+              description: |
+                Number of retries left for the task in case of infrastructure issues
+              maximum: 999
+              minimum: 0
+              title: Retries Left
+              type: integer
+            runs:
+              IS_REQUIRED: true
+              PROPERTY_NAME: runs
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs
+              TYPE_NAME: ListOfRuns
+              description: |
+                List of runs, ordered so that index `i` has `runId == i`
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: runs entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+                TYPE_NAME: RunInformation
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                description: |
+                  JSON object with information about a run
+                properties:
+                  MemberNames:
+                    reasonCreated: ReasonCreated
+                    reasonResolved: ReasonResolved
+                    resolved: Resolved
+                    runId: RunID
+                    scheduled: Scheduled
+                    started: Started
+                    state: State
+                    takenUntil: TakenUntil
+                    workerGroup: WorkerGroup
+                    workerId: WorkerID
+                  Properties:
+                    reasonCreated:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: reasonCreated
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+                      TYPE_NAME: ReasonCreated
+                      description: |
+                        Reason for the creation of this run,
+                        **more reasons may be added in the future**.
+                      enum:
+                      - scheduled
+                      - retry
+                      - task-retry
+                      - rerun
+                      - exception
+                      title: Reason Created
+                      type: string
+                    reasonResolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: reasonResolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+                      TYPE_NAME: ReasonResolved
+                      description: |
+                        Reason that run was resolved, this is mainly
+                        useful for runs resolved as `exception`.
+                        Note, **more reasons may be added in the future**, also this
+                        property is only available after the run is resolved. Some of these
+                        reasons, notably `intermittent-task`, `worker-shutdown`, and
+                        `claim-expired`, will trigger an automatic retry of the task.
+                      enum:
+                      - completed
+                      - failed
+                      - deadline-exceeded
+                      - canceled
+                      - superseded
+                      - claim-expired
+                      - worker-shutdown
+                      - malformed-payload
+                      - resource-unavailable
+                      - internal-error
+                      - intermittent-task
+                      title: Reason Resolved
+                      type: string
+                    resolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: resolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+                      TYPE_NAME: Resolved
+                      description: |
+                        Date-time at which this run was resolved, ie. when the run changed
+                        state from `running` to either `completed`, `failed` or `exception`.
+                        This property is only present after the run as been resolved.
+                      format: date-time
+                      title: Resolved
+                      type: string
+                    runId:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: runId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+                      TYPE_NAME: RunIdentifier
+                      description: |
+                        Id of this task run, `run-id`s always starts from `0`
+                      maximum: 1000
+                      minimum: 0
+                      title: Run Identifier
+                      type: integer
+                    scheduled:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: scheduled
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+                      TYPE_NAME: Scheduled
+                      description: |
+                        Date-time at which this run was scheduled, ie. when the run was
+                        created in state `pending`.
+                      format: date-time
+                      title: Scheduled
+                      type: string
+                    started:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: started
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+                      TYPE_NAME: Started
+                      description: |
+                        Date-time at which this run was claimed, ie. when the run changed
+                        state from `pending` to `running`. This property is only present
+                        after the run has been claimed.
+                      format: date-time
+                      title: Started
+                      type: string
+                    state:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: state
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+                      TYPE_NAME: RunState
+                      description: |
+                        State of this run
+                      enum:
+                      - pending
+                      - running
+                      - completed
+                      - failed
+                      - exception
+                      title: Run State
+                      type: string
+                    takenUntil:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: takenUntil
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+                      TYPE_NAME: TakenUntil
+                      description: |
+                        Time at which the run expires and is resolved as `failed`, if the
+                        run isn't reclaimed. Note, only present after the run has been
+                        claimed.
+                      format: date-time
+                      title: Taken Until
+                      type: string
+                    workerGroup:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerGroup
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+                      TYPE_NAME: WorkerGroup
+                      description: |
+                        Identifier for group that worker who executes this run is a part of,
+                        this identifier is mainly used for efficient routing.
+                        Note, this property is only present after the run is claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Group
+                      type: string
+                    workerId:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+                      TYPE_NAME: WorkerIdentifier
+                      description: |
+                        Identifier for worker evaluating this run within given
+                        `workerGroup`. Note, this property is only available after the run
+                        has been claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Identifier
+                      type: string
+                  SortedPropertyNames:
+                  - reasonCreated
+                  - reasonResolved
+                  - resolved
+                  - runId
+                  - scheduled
+                  - started
+                  - state
+                  - takenUntil
+                  - workerGroup
+                  - workerId
+                  SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties
+                required:
+                - runId
+                - state
+                - reasonCreated
+                - scheduled
+                title: Run Information
+                type: object
+              title: List of Runs
+              type: array
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            state:
+              IS_REQUIRED: true
+              PROPERTY_NAME: state
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/state
+              TYPE_NAME: State
+              description: |
+                State of this task. This is just an auxiliary property derived from state
+                of latests run, or `unscheduled` if none.
+              enum:
+              - unscheduled
+              - pending
+              - running
+              - completed
+              - failed
+              - exception
+              title: State
+              type: string
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            taskId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskId
+              TYPE_NAME: TaskIdentifier
+              description: |
+                Unique task identifier, this is UUID encoded as
+                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+                stripped of `=` padding.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Identifier for worker type within the specified provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - deadline
+          - expires
+          - provisionerId
+          - retriesLeft
+          - runs
+          - schedulerId
+          - state
+          - taskGroupId
+          - taskId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties
+        required:
+        - taskId
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - deadline
+        - expires
+        - retriesLeft
+        - state
+        - runs
+        title: Task Status Structure
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/status
+      TYPE_NAME: Status
+    task:
+      $ref: http://schemas.taskcluster.net/queue/v1/task.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: task
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#
+        TYPE_NAME: TaskDefinitionResponse
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          Definition of a task that can be scheduled
+        id: http://schemas.taskcluster.net/queue/v1/task.json#
+        properties:
+          MemberNames:
+            created: Created
+            deadline: Deadline
+            dependencies: Dependencies
+            expires: Expires
+            extra: Extra
+            metadata: Metadata
+            payload: Payload
+            priority: Priority
+            provisionerId: ProvisionerID
+            requires: Requires
+            retries: Retries
+            routes: Routes
+            schedulerId: SchedulerID
+            scopes: Scopes
+            tags: Tags
+            taskGroupId: TaskGroupID
+            workerType: WorkerType
+          Properties:
+            created:
+              IS_REQUIRED: true
+              PROPERTY_NAME: created
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/created
+              TYPE_NAME: Created
+              description: Creation time of task
+              format: date-time
+              title: Created
+              type: string
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            dependencies:
+              IS_REQUIRED: true
+              PROPERTY_NAME: dependencies
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies
+              TYPE_NAME: TaskDependencies
+              description: |
+                List of dependent tasks. These must either be _completed_ or _resolved_
+                before this task is scheduled. See `requires` for semantics.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: dependencies entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies/items
+                TYPE_NAME: TaskDependency
+                description: |
+                  The `taskId` of a task that must be resolved before this task is
+                  scheduled.
+                pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+                title: Task Dependency
+                type: string
+              maxItems: 100
+              title: Task Dependencies
+              type: array
+              uniqueItems: true
+            expires:
+              IS_REQUIRED: false
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and status is deleted.
+                Notice that all artifacts for the task must have an expiration that is no
+                later than this. If this property isn't it will be set to `deadline`
+                plus one year (this default may subject to change).
+              format: date-time
+              title: Expiration
+              type: string
+            extra:
+              IS_REQUIRED: true
+              PROPERTY_NAME: extra
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/extra
+              TYPE_NAME: ExtraData
+              default: {}
+              description: |
+                Object with properties that can hold any kind of extra data that should be
+                associated with the task. This can be data for the task which doesn't
+                fit into `payload`, or it can supplementary data for use in services
+                listening for events from this task. For example this could be details to
+                display on _treeherder_, or information for indexing the task. Please, try
+                to put all related information under one property, so `extra` data keys
+                for treeherder reporting and task indexing don't conflict, hence, we have
+                reusable services. **Warning**, do not stuff large data-sets in here,
+                task definitions should not take-up multiple MiBs.
+              title: Extra Data
+              type: object
+            metadata:
+              IS_REQUIRED: true
+              PROPERTY_NAME: metadata
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+              TYPE_NAME: MetaData
+              additionalProperties:
+                Boolean: false
+                Properties: null
+              description: |
+                Required task metadata
+              properties:
+                MemberNames:
+                  description: Description
+                  name: Name
+                  owner: Owner
+                  source: Source
+                Properties:
+                  description:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: description
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
+                    TYPE_NAME: Description
+                    description: |
+                      Human readable description of the task, please **explain** what the
+                      task does. A few lines of documentation is not going to hurt you.
+                    maxLength: 32768
+                    title: Description
+                    type: string
+                  name:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: name
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
+                    TYPE_NAME: Name
+                    description: |
+                      Human readable name of task, used to very briefly given an idea about
+                      what the task does.
+                    maxLength: 255
+                    title: Name
+                    type: string
+                  owner:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: owner
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
+                    TYPE_NAME: Owner
+                    description: |
+                      E-mail of person who caused this task, e.g. the person who did
+                      `hg push`. The person we should contact to ask why this task is here.
+                    format: email
+                    maxLength: 255
+                    title: Owner
+                    type: string
+                  source:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: source
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
+                    TYPE_NAME: Source
+                    description: |
+                      Link to source of this task, should specify a file, revision and
+                      repository. This should be place someone can go an do a git/hg blame
+                      to who came up with recipe for this task.
+                    format: uri
+                    maxLength: 4096
+                    pattern: ^https?://
+                    title: Source
+                    type: string
+                SortedPropertyNames:
+                - description
+                - name
+                - owner
+                - source
+                SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties
+              required:
+              - name
+              - description
+              - owner
+              - source
+              title: Meta-data
+              type: object
+            payload:
+              IS_REQUIRED: true
+              PROPERTY_NAME: payload
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/payload
+              TYPE_NAME: TaskPayload
+              description: |
+                Task-specific payload following worker-specific format. For example the
+                `docker-worker` requires keys like: `image`, `commands` and
+                `features`. Refer to the documentation of `docker-worker` for details.
+              title: Task Payload
+              type: object
+            priority:
+              IS_REQUIRED: true
+              PROPERTY_NAME: priority
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/priority
+              TYPE_NAME: TaskPriority
+              description: |
+                Priority of task, this defaults to `lowest` and the scope
+                `queue:create-task:<priority>/<provisionerId>/<workerType>` is required
+                to define a task with `<priority>`.
+              enum:
+              - highest
+              - very-high
+              - high
+              - medium
+              - low
+              - very-low
+              - lowest
+              title: Task Priority
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for a provisioner, that can supply specified
+                `workerType`
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            requires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: requires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/requires
+              TYPE_NAME: DependencyRequirementSemantics
+              description: |
+                The tasks relation to its dependencies. This property specifies the
+                semantics of the `task.dependencies` property.
+                If `all-completed` is given the task will be scheduled when all
+                dependencies are resolved _completed_ (successful resolution).
+                If `all-resolved` is given the task will be scheduled when all dependencies
+                have been resolved, regardless of what their resolution is.
+              enum:
+              - all-completed
+              - all-resolved
+              title: Dependency Requirement Semantics
+              type: string
+            retries:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retries
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/retries
+              TYPE_NAME: Retries
+              description: |
+                Number of times to retry the task in case of infrastructure issues.
+                An _infrastructure issue_ is a worker node that crashes or is shutdown,
+                these events are to be expected.
+              maximum: 49
+              minimum: 0
+              title: Retries
+              type: integer
+            routes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: routes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes
+              TYPE_NAME: TaskSpecificRoutes
+              description: |
+                List of task specific routes, AMQP messages will be CC'ed to these routes.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: routes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes/items
+                TYPE_NAME: TaskSpecificRoute
+                description: |
+                  A task specific route, AMQP messages will be CC'ed with a routing key
+                  matching `route.<task-specific route>`. It's possible to dot (`.`) in
+                  the task specific route to make sub-keys, etc. See the RabbitMQ
+                  [tutorial](http://www.rabbitmq.com/tutorials/tutorial-five-python.html)
+                  for examples on how to use routing-keys.
+                maxLength: 249
+                minLength: 1
+                title: Task Specific Route
+                type: string
+              maxItems: 64
+              title: Task Specific Routes
+              type: array
+              uniqueItems: true
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task, this can be an
+                identifier for a user or a service like the `"task-graph-scheduler"`.
+                Along with the `taskGroupId` this is used to form the permission scope
+                `queue:assume:scheduler-id:<schedulerId>/<taskGroupId>`,
+                this scope is necessary to _schedule_ a defined task, or _rerun_ a task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            scopes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: scopes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes
+              TYPE_NAME: Scopes
+              description: |
+                List of scopes (or scope-patterns) that the task is
+                authorized to use.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: scopes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes/items
+                TYPE_NAME: Scope
+                description: |
+                  A scope (or scope-patterns) which the task is
+                  authorized to use. This can be a string or a string
+                  ending with `*` which will authorize all scopes for
+                  which the string is a prefix.  Scopes must be composed of
+                  printable ASCII characters and spaces.
+                pattern: ^[\x20-\x7e]*$
+                title: Scope
+                type: string
+              title: Scopes
+              type: array
+            tags:
+              IS_REQUIRED: true
+              PROPERTY_NAME: tags
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/tags
+              TYPE_NAME: Tags
+              additionalProperties:
+                Boolean: null
+                Properties:
+                  IS_REQUIRED: false
+                  PROPERTY_NAME: ""
+                  SOURCE_URL: ""
+                  TYPE_NAME: ""
+                  maxLength: 4096
+                  type: string
+              description: |
+                Arbitrary key-value tags (only strings limited to 4k). These can be used
+                to attach informal meta-data to a task. Use this for informal tags that
+                tasks can be classified by. You can also think of strings here as
+                candidates for formal meta-data. Something like
+                `purpose: 'build' || 'test'` is a good example.
+              title: Tags
+              type: object
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.  Defaults to `taskId` if
+                property isn't specified.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Unique identifier for a worker-type within a specific provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - created
+          - deadline
+          - dependencies
+          - expires
+          - extra
+          - metadata
+          - payload
+          - priority
+          - provisionerId
+          - requires
+          - retries
+          - routes
+          - schedulerId
+          - scopes
+          - tags
+          - taskGroupId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties
+        required:
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - dependencies
+        - requires
+        - routes
+        - priority
+        - retries
+        - created
+        - deadline
+        - scopes
+        - payload
+        - metadata
+        - tags
+        - extra
+        title: Task Definition Response
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/task
+      TYPE_NAME: Task
+  SortedPropertyNames:
+  - status
+  - task
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties
+required:
+- task
+- status
+title: Task definition and status
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#
 ========================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -12343,130 +16571,164 @@ properties:
             stability: Stability
           Properties:
             actions:
+              $ref: http://schemas.taskcluster.net/queue/v1/actions.json#
               IS_REQUIRED: true
               PROPERTY_NAME: actions
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions
-              TYPE_NAME: Actions
-              items:
+              REF_SUBSCHEMA:
+                $schema: http://json-schema.org/draft-06/schema#
                 IS_REQUIRED: false
-                PROPERTY_NAME: actions entry
-                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items
-                TYPE_NAME: Actions1
-                additionalProperties:
-                  Boolean: false
-                  Properties: null
+                PROPERTY_NAME: ""
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#
+                TYPE_NAME: Actions3
                 description: |
-                  Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
-                  Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
-                  used by the front-end to know where to display the action. For example, `context=worker`
-                  will display the action on the worker explorer.
+                  See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+                id: http://schemas.taskcluster.net/queue/v1/actions.json#
+                items:
+                  IS_REQUIRED: false
+                  PROPERTY_NAME: ' entry'
+                  SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+                  TYPE_NAME: Actions4
+                  additionalProperties:
+                    Boolean: false
+                    Properties: null
+                  description: |
+                    Actions provide a generic mechanism to expose additional features of a
+                    provisioner, worker type, or worker to Taskcluster clients.
 
-                  _Note: The request will be signed with the user's Taskcluster credentials._
-                properties:
-                  MemberNames:
-                    context: Context
-                    description: Description
-                    method: Method
-                    name: Name
-                    title: Title
-                    url: URL
-                  Properties:
-                    context:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: context
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/context
-                      TYPE_NAME: Context
-                      description: |
-                        Actions have a "context" that is one of provisioner, worker-type,
-                        or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
+                    An action is comprised of metadata describing the feature it exposes,
+                    together with a webhook for triggering it.
 
-                        | `context`   | Page displayed        |
-                        |-------------|-----------------------|
-                        | provisioner | Provisioner Explorer  |
-                        | worker-type | Workers Explorer      |
-                        | worker      | Worker Explorer       |
-                      enum:
-                      - provisioner
-                      - worker-type
-                      - worker
-                      title: Context
-                      type: string
-                    description:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: description
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/description
-                      TYPE_NAME: Description
-                      description: |
-                        Description of the provisioner.
-                      title: Description
-                      type: string
-                    method:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: method
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/method
-                      TYPE_NAME: Method
-                      description: |
-                        Method to indicate the desired action to be performed for a given resource.
-                      enum:
-                      - POST
-                      - PUT
-                      - DELETE
-                      - PATCH
-                      title: Method
-                      type: string
-                    name:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: name
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/name
-                      TYPE_NAME: Name
-                      description: |
-                        Short names for things like logging/error messages.
-                      title: Name
-                      type: string
-                    title:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: title
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/title
-                      TYPE_NAME: Title
-                      description: |
-                        Appropriate title for any sort of Modal prompt.
+                    The Taskcluster tools site, for example, retrieves actions when displaying
+                    provisioners, worker types and workers. It presents the provisioner/worker
+                    type/worker specific actions to the user. When the user triggers an action,
+                    the web client takes the registered webhook, substitutes parameters into the
+                    URL (see `url`), signs the requests with the Taskcluster credentials of the
+                    user operating the web interface, and issues the HTTP request.
+
+                    The level to which the action relates (provisioner, worker type, worker) is
+                    called the action context. All actions, regardless of the action contexts,
+                    are registered against the provisioner when calling
+                    `queue.declareProvisioner`.
+
+                    The action context is used by the web client to determine where in the web
+                    interface to present the action to the user as follows:
+
+                    | `context`   | Tool where action is displayed |
+                    |-------------|--------------------------------|
+                    | provisioner | Provisioner Explorer           |
+                    | worker-type | Workers Explorer               |
+                    | worker      | Worker Explorer                |
+
+                    See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+                    for more information.
+                  properties:
+                    MemberNames:
+                      context: Context
+                      description: Description
+                      method: Method
+                      name: Name
                       title: Title
-                    url:
-                      IS_REQUIRED: true
-                      PROPERTY_NAME: url
-                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/url
-                      TYPE_NAME: URL
-                      description: |
-                        When an action is triggered, a request is made using the `url` and `method`.
-                        Depending on the `context`, the following parameters will be substituted in the url:
+                      url: URL
+                    Properties:
+                      context:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: context
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+                        TYPE_NAME: Context
+                        description: |
+                          Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+                          which it applies to. `context` is used by the front-end to know where to display the action.
 
-                        | `context`   | Path parameters                                          |
-                        |-------------|----------------------------------------------------------|
-                        | provisioner | <provisionerId>                                          |
-                        | worker-type | <provisionerId>, <workerType>                            |
-                        | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+                          | `context`   | Page displayed        |
+                          |-------------|-----------------------|
+                          | provisioner | Provisioner Explorer  |
+                          | worker-type | Workers Explorer      |
+                          | worker      | Worker Explorer       |
+                        enum:
+                        - provisioner
+                        - worker-type
+                        - worker
+                        title: Context
+                        type: string
+                      description:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: description
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+                        TYPE_NAME: Description
+                        description: |
+                          Description of the provisioner.
+                        title: Description
+                        type: string
+                      method:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: method
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+                        TYPE_NAME: Method
+                        description: |
+                          Method to indicate the desired action to be performed for a given resource.
+                        enum:
+                        - POST
+                        - PUT
+                        - DELETE
+                        - PATCH
+                        title: Method
+                        type: string
+                      name:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: name
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+                        TYPE_NAME: Name
+                        description: |
+                          Short names for things like logging/error messages.
+                        title: Name
+                        type: string
+                      title:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: title
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+                        TYPE_NAME: Title
+                        description: |
+                          Appropriate title for any sort of Modal prompt.
+                        title: Title
+                      url:
+                        IS_REQUIRED: true
+                        PROPERTY_NAME: url
+                        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+                        TYPE_NAME: URL
+                        description: |
+                          When an action is triggered, a request is made using the `url` and `method`.
+                          Depending on the `context`, the following parameters will be substituted in the url:
 
-                        _Note: The request needs to be signed with the user's Taskcluster credentials._
-                      title: URL
-                      type: string
-                  SortedPropertyNames:
-                  - context
-                  - description
-                  - method
+                          | `context`   | Path parameters                                          |
+                          |-------------|----------------------------------------------------------|
+                          | provisioner | <provisionerId>                                          |
+                          | worker-type | <provisionerId>, <workerType>                            |
+                          | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+                          _Note: The request needs to be signed with the user's Taskcluster credentials._
+                        title: URL
+                        type: string
+                    SortedPropertyNames:
+                    - context
+                    - description
+                    - method
+                    - name
+                    - title
+                    - url
+                    SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+                  required:
                   - name
                   - title
+                  - context
                   - url
-                  SourceURL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties
-                required:
-                - name
-                - title
-                - context
-                - url
-                - method
-                - description
+                  - method
+                  - description
+                  title: Actions
+                  type: object
                 title: Actions
-                type: object
-              type: array
+                type: array
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions
+              TYPE_NAME: Actions
             description:
               IS_REQUIRED: true
               PROPERTY_NAME: description
@@ -12548,6 +16810,258 @@ properties:
 required:
 - provisioners
 title: List Provisioners Response
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items
+======================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: provisioners entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items
+TYPE_NAME: ProvisionerInformation
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    actions: Actions
+    description: Description
+    expires: Expires
+    lastDateActive: LastDateActive
+    provisionerId: ProvisionerID
+    stability: Stability
+  Properties:
+    actions:
+      $ref: http://schemas.taskcluster.net/queue/v1/actions.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: actions
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#
+        TYPE_NAME: Actions3
+        description: |
+          See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+        id: http://schemas.taskcluster.net/queue/v1/actions.json#
+        items:
+          IS_REQUIRED: false
+          PROPERTY_NAME: ' entry'
+          SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+          TYPE_NAME: Actions4
+          additionalProperties:
+            Boolean: false
+            Properties: null
+          description: |
+            Actions provide a generic mechanism to expose additional features of a
+            provisioner, worker type, or worker to Taskcluster clients.
+
+            An action is comprised of metadata describing the feature it exposes,
+            together with a webhook for triggering it.
+
+            The Taskcluster tools site, for example, retrieves actions when displaying
+            provisioners, worker types and workers. It presents the provisioner/worker
+            type/worker specific actions to the user. When the user triggers an action,
+            the web client takes the registered webhook, substitutes parameters into the
+            URL (see `url`), signs the requests with the Taskcluster credentials of the
+            user operating the web interface, and issues the HTTP request.
+
+            The level to which the action relates (provisioner, worker type, worker) is
+            called the action context. All actions, regardless of the action contexts,
+            are registered against the provisioner when calling
+            `queue.declareProvisioner`.
+
+            The action context is used by the web client to determine where in the web
+            interface to present the action to the user as follows:
+
+            | `context`   | Tool where action is displayed |
+            |-------------|--------------------------------|
+            | provisioner | Provisioner Explorer           |
+            | worker-type | Workers Explorer               |
+            | worker      | Worker Explorer                |
+
+            See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+            for more information.
+          properties:
+            MemberNames:
+              context: Context
+              description: Description
+              method: Method
+              name: Name
+              title: Title
+              url: URL
+            Properties:
+              context:
+                IS_REQUIRED: true
+                PROPERTY_NAME: context
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+                TYPE_NAME: Context
+                description: |
+                  Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+                  which it applies to. `context` is used by the front-end to know where to display the action.
+
+                  | `context`   | Page displayed        |
+                  |-------------|-----------------------|
+                  | provisioner | Provisioner Explorer  |
+                  | worker-type | Workers Explorer      |
+                  | worker      | Worker Explorer       |
+                enum:
+                - provisioner
+                - worker-type
+                - worker
+                title: Context
+                type: string
+              description:
+                IS_REQUIRED: true
+                PROPERTY_NAME: description
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+                TYPE_NAME: Description
+                description: |
+                  Description of the provisioner.
+                title: Description
+                type: string
+              method:
+                IS_REQUIRED: true
+                PROPERTY_NAME: method
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+                TYPE_NAME: Method
+                description: |
+                  Method to indicate the desired action to be performed for a given resource.
+                enum:
+                - POST
+                - PUT
+                - DELETE
+                - PATCH
+                title: Method
+                type: string
+              name:
+                IS_REQUIRED: true
+                PROPERTY_NAME: name
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+                TYPE_NAME: Name
+                description: |
+                  Short names for things like logging/error messages.
+                title: Name
+                type: string
+              title:
+                IS_REQUIRED: true
+                PROPERTY_NAME: title
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+                TYPE_NAME: Title
+                description: |
+                  Appropriate title for any sort of Modal prompt.
+                title: Title
+              url:
+                IS_REQUIRED: true
+                PROPERTY_NAME: url
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+                TYPE_NAME: URL
+                description: |
+                  When an action is triggered, a request is made using the `url` and `method`.
+                  Depending on the `context`, the following parameters will be substituted in the url:
+
+                  | `context`   | Path parameters                                          |
+                  |-------------|----------------------------------------------------------|
+                  | provisioner | <provisionerId>                                          |
+                  | worker-type | <provisionerId>, <workerType>                            |
+                  | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+                  _Note: The request needs to be signed with the user's Taskcluster credentials._
+                title: URL
+                type: string
+            SortedPropertyNames:
+            - context
+            - description
+            - method
+            - name
+            - title
+            - url
+            SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+          required:
+          - name
+          - title
+          - context
+          - url
+          - method
+          - description
+          title: Actions
+          type: object
+        title: Actions
+        type: array
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions
+      TYPE_NAME: Actions
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/description
+      TYPE_NAME: Description
+      description: |
+        Description of the provisioner.
+      title: Description
+      type: string
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/expires
+      TYPE_NAME: ProvisionerExpiration
+      description: |
+        Date and time after which the provisioner created will be automatically
+        deleted by the queue.
+      format: date-time
+      title: Provisioner Expiration
+      type: string
+    lastDateActive:
+      IS_REQUIRED: true
+      PROPERTY_NAME: lastDateActive
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/lastDateActive
+      TYPE_NAME: ProvisionerLastDateActive
+      description: |
+        Date and time where the provisioner was last seen active
+      format: date-time
+      title: Provisioner Last Date Active
+      type: string
+    provisionerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: provisionerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/provisionerId
+      TYPE_NAME: ProvisionerID
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Provisioner ID
+      type: string
+    stability:
+      IS_REQUIRED: true
+      PROPERTY_NAME: stability
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/stability
+      TYPE_NAME: Stability
+      description: |
+        This is the stability of the provisioner. Accepted values:
+         * `experimental`
+         * `stable`
+         * `deprecated`
+      enum:
+      - experimental
+      - stable
+      - deprecated
+      title: Stability
+      type: string
+  SortedPropertyNames:
+  - actions
+  - description
+  - expires
+  - lastDateActive
+  - provisionerId
+  - stability
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties
+required:
+- provisionerId
+- description
+- stability
+- expires
+- lastDateActive
+- actions
+title: Provisioner Information
 type: object
 
 
@@ -13419,6 +17933,812 @@ title: List Task-Group Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items
+=============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: tasks entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items
+TYPE_NAME: TaskDefinitionAndStatus
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Task Definition and task status structure.
+properties:
+  MemberNames:
+    status: Status
+    task: Task
+  Properties:
+    status:
+      $ref: http://schemas.taskcluster.net/queue/v1/task-status.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: status
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        TYPE_NAME: TaskStatusStructure
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          A representation of **task status** as known by the queue
+        id: http://schemas.taskcluster.net/queue/v1/task-status.json#
+        properties:
+          MemberNames:
+            deadline: Deadline
+            expires: Expires
+            provisionerId: ProvisionerID
+            retriesLeft: RetriesLeft
+            runs: Runs
+            schedulerId: SchedulerID
+            state: State
+            taskGroupId: TaskGroupID
+            taskId: TaskID
+            workerType: WorkerType
+          Properties:
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            expires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and
+                status is deleted. Notice that all artifacts for the task
+                must have an expiration that is no later than this.
+              format: date-time
+              title: Expiration
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for the provisioner that this task must be scheduled on
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            retriesLeft:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retriesLeft
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/retriesLeft
+              TYPE_NAME: RetriesLeft
+              description: |
+                Number of retries left for the task in case of infrastructure issues
+              maximum: 999
+              minimum: 0
+              title: Retries Left
+              type: integer
+            runs:
+              IS_REQUIRED: true
+              PROPERTY_NAME: runs
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs
+              TYPE_NAME: ListOfRuns
+              description: |
+                List of runs, ordered so that index `i` has `runId == i`
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: runs entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+                TYPE_NAME: RunInformation
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                description: |
+                  JSON object with information about a run
+                properties:
+                  MemberNames:
+                    reasonCreated: ReasonCreated
+                    reasonResolved: ReasonResolved
+                    resolved: Resolved
+                    runId: RunID
+                    scheduled: Scheduled
+                    started: Started
+                    state: State
+                    takenUntil: TakenUntil
+                    workerGroup: WorkerGroup
+                    workerId: WorkerID
+                  Properties:
+                    reasonCreated:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: reasonCreated
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+                      TYPE_NAME: ReasonCreated
+                      description: |
+                        Reason for the creation of this run,
+                        **more reasons may be added in the future**.
+                      enum:
+                      - scheduled
+                      - retry
+                      - task-retry
+                      - rerun
+                      - exception
+                      title: Reason Created
+                      type: string
+                    reasonResolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: reasonResolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+                      TYPE_NAME: ReasonResolved
+                      description: |
+                        Reason that run was resolved, this is mainly
+                        useful for runs resolved as `exception`.
+                        Note, **more reasons may be added in the future**, also this
+                        property is only available after the run is resolved. Some of these
+                        reasons, notably `intermittent-task`, `worker-shutdown`, and
+                        `claim-expired`, will trigger an automatic retry of the task.
+                      enum:
+                      - completed
+                      - failed
+                      - deadline-exceeded
+                      - canceled
+                      - superseded
+                      - claim-expired
+                      - worker-shutdown
+                      - malformed-payload
+                      - resource-unavailable
+                      - internal-error
+                      - intermittent-task
+                      title: Reason Resolved
+                      type: string
+                    resolved:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: resolved
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+                      TYPE_NAME: Resolved
+                      description: |
+                        Date-time at which this run was resolved, ie. when the run changed
+                        state from `running` to either `completed`, `failed` or `exception`.
+                        This property is only present after the run as been resolved.
+                      format: date-time
+                      title: Resolved
+                      type: string
+                    runId:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: runId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+                      TYPE_NAME: RunIdentifier
+                      description: |
+                        Id of this task run, `run-id`s always starts from `0`
+                      maximum: 1000
+                      minimum: 0
+                      title: Run Identifier
+                      type: integer
+                    scheduled:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: scheduled
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+                      TYPE_NAME: Scheduled
+                      description: |
+                        Date-time at which this run was scheduled, ie. when the run was
+                        created in state `pending`.
+                      format: date-time
+                      title: Scheduled
+                      type: string
+                    started:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: started
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+                      TYPE_NAME: Started
+                      description: |
+                        Date-time at which this run was claimed, ie. when the run changed
+                        state from `pending` to `running`. This property is only present
+                        after the run has been claimed.
+                      format: date-time
+                      title: Started
+                      type: string
+                    state:
+                      IS_REQUIRED: true
+                      PROPERTY_NAME: state
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+                      TYPE_NAME: RunState
+                      description: |
+                        State of this run
+                      enum:
+                      - pending
+                      - running
+                      - completed
+                      - failed
+                      - exception
+                      title: Run State
+                      type: string
+                    takenUntil:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: takenUntil
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+                      TYPE_NAME: TakenUntil
+                      description: |
+                        Time at which the run expires and is resolved as `failed`, if the
+                        run isn't reclaimed. Note, only present after the run has been
+                        claimed.
+                      format: date-time
+                      title: Taken Until
+                      type: string
+                    workerGroup:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerGroup
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+                      TYPE_NAME: WorkerGroup
+                      description: |
+                        Identifier for group that worker who executes this run is a part of,
+                        this identifier is mainly used for efficient routing.
+                        Note, this property is only present after the run is claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Group
+                      type: string
+                    workerId:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: workerId
+                      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+                      TYPE_NAME: WorkerIdentifier
+                      description: |
+                        Identifier for worker evaluating this run within given
+                        `workerGroup`. Note, this property is only available after the run
+                        has been claimed.
+                      maxLength: 22
+                      minLength: 1
+                      pattern: ^([a-zA-Z0-9-_]*)$
+                      title: Worker Identifier
+                      type: string
+                  SortedPropertyNames:
+                  - reasonCreated
+                  - reasonResolved
+                  - resolved
+                  - runId
+                  - scheduled
+                  - started
+                  - state
+                  - takenUntil
+                  - workerGroup
+                  - workerId
+                  SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties
+                required:
+                - runId
+                - state
+                - reasonCreated
+                - scheduled
+                title: Run Information
+                type: object
+              title: List of Runs
+              type: array
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            state:
+              IS_REQUIRED: true
+              PROPERTY_NAME: state
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/state
+              TYPE_NAME: State
+              description: |
+                State of this task. This is just an auxiliary property derived from state
+                of latests run, or `unscheduled` if none.
+              enum:
+              - unscheduled
+              - pending
+              - running
+              - completed
+              - failed
+              - exception
+              title: State
+              type: string
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            taskId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/taskId
+              TYPE_NAME: TaskIdentifier
+              description: |
+                Unique task identifier, this is UUID encoded as
+                [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+                stripped of `=` padding.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Identifier for worker type within the specified provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - deadline
+          - expires
+          - provisionerId
+          - retriesLeft
+          - runs
+          - schedulerId
+          - state
+          - taskGroupId
+          - taskId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties
+        required:
+        - taskId
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - deadline
+        - expires
+        - retriesLeft
+        - state
+        - runs
+        title: Task Status Structure
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/status
+      TYPE_NAME: Status
+    task:
+      $ref: http://schemas.taskcluster.net/queue/v1/task.json#
+      IS_REQUIRED: true
+      PROPERTY_NAME: task
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
+        IS_REQUIRED: false
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#
+        TYPE_NAME: TaskDefinitionResponse
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          Definition of a task that can be scheduled
+        id: http://schemas.taskcluster.net/queue/v1/task.json#
+        properties:
+          MemberNames:
+            created: Created
+            deadline: Deadline
+            dependencies: Dependencies
+            expires: Expires
+            extra: Extra
+            metadata: Metadata
+            payload: Payload
+            priority: Priority
+            provisionerId: ProvisionerID
+            requires: Requires
+            retries: Retries
+            routes: Routes
+            schedulerId: SchedulerID
+            scopes: Scopes
+            tags: Tags
+            taskGroupId: TaskGroupID
+            workerType: WorkerType
+          Properties:
+            created:
+              IS_REQUIRED: true
+              PROPERTY_NAME: created
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/created
+              TYPE_NAME: Created
+              description: Creation time of task
+              format: date-time
+              title: Created
+              type: string
+            deadline:
+              IS_REQUIRED: true
+              PROPERTY_NAME: deadline
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/deadline
+              TYPE_NAME: Deadline
+              description: |
+                Deadline of the task, `pending` and `running` runs are
+                resolved as **exception** if not resolved by other means
+                before the deadline. Note, deadline cannot be more than
+                5 days into the future
+              format: date-time
+              title: Deadline
+              type: string
+            dependencies:
+              IS_REQUIRED: true
+              PROPERTY_NAME: dependencies
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies
+              TYPE_NAME: TaskDependencies
+              description: |
+                List of dependent tasks. These must either be _completed_ or _resolved_
+                before this task is scheduled. See `requires` for semantics.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: dependencies entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/dependencies/items
+                TYPE_NAME: TaskDependency
+                description: |
+                  The `taskId` of a task that must be resolved before this task is
+                  scheduled.
+                pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+                title: Task Dependency
+                type: string
+              maxItems: 100
+              title: Task Dependencies
+              type: array
+              uniqueItems: true
+            expires:
+              IS_REQUIRED: false
+              PROPERTY_NAME: expires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/expires
+              TYPE_NAME: Expiration
+              description: |
+                Task expiration, time at which task definition and status is deleted.
+                Notice that all artifacts for the task must have an expiration that is no
+                later than this. If this property isn't it will be set to `deadline`
+                plus one year (this default may subject to change).
+              format: date-time
+              title: Expiration
+              type: string
+            extra:
+              IS_REQUIRED: true
+              PROPERTY_NAME: extra
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/extra
+              TYPE_NAME: ExtraData
+              default: {}
+              description: |
+                Object with properties that can hold any kind of extra data that should be
+                associated with the task. This can be data for the task which doesn't
+                fit into `payload`, or it can supplementary data for use in services
+                listening for events from this task. For example this could be details to
+                display on _treeherder_, or information for indexing the task. Please, try
+                to put all related information under one property, so `extra` data keys
+                for treeherder reporting and task indexing don't conflict, hence, we have
+                reusable services. **Warning**, do not stuff large data-sets in here,
+                task definitions should not take-up multiple MiBs.
+              title: Extra Data
+              type: object
+            metadata:
+              IS_REQUIRED: true
+              PROPERTY_NAME: metadata
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+              TYPE_NAME: MetaData
+              additionalProperties:
+                Boolean: false
+                Properties: null
+              description: |
+                Required task metadata
+              properties:
+                MemberNames:
+                  description: Description
+                  name: Name
+                  owner: Owner
+                  source: Source
+                Properties:
+                  description:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: description
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
+                    TYPE_NAME: Description
+                    description: |
+                      Human readable description of the task, please **explain** what the
+                      task does. A few lines of documentation is not going to hurt you.
+                    maxLength: 32768
+                    title: Description
+                    type: string
+                  name:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: name
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
+                    TYPE_NAME: Name
+                    description: |
+                      Human readable name of task, used to very briefly given an idea about
+                      what the task does.
+                    maxLength: 255
+                    title: Name
+                    type: string
+                  owner:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: owner
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
+                    TYPE_NAME: Owner
+                    description: |
+                      E-mail of person who caused this task, e.g. the person who did
+                      `hg push`. The person we should contact to ask why this task is here.
+                    format: email
+                    maxLength: 255
+                    title: Owner
+                    type: string
+                  source:
+                    IS_REQUIRED: true
+                    PROPERTY_NAME: source
+                    SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
+                    TYPE_NAME: Source
+                    description: |
+                      Link to source of this task, should specify a file, revision and
+                      repository. This should be place someone can go an do a git/hg blame
+                      to who came up with recipe for this task.
+                    format: uri
+                    maxLength: 4096
+                    pattern: ^https?://
+                    title: Source
+                    type: string
+                SortedPropertyNames:
+                - description
+                - name
+                - owner
+                - source
+                SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties
+              required:
+              - name
+              - description
+              - owner
+              - source
+              title: Meta-data
+              type: object
+            payload:
+              IS_REQUIRED: true
+              PROPERTY_NAME: payload
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/payload
+              TYPE_NAME: TaskPayload
+              description: |
+                Task-specific payload following worker-specific format. For example the
+                `docker-worker` requires keys like: `image`, `commands` and
+                `features`. Refer to the documentation of `docker-worker` for details.
+              title: Task Payload
+              type: object
+            priority:
+              IS_REQUIRED: true
+              PROPERTY_NAME: priority
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/priority
+              TYPE_NAME: TaskPriority
+              description: |
+                Priority of task, this defaults to `lowest` and the scope
+                `queue:create-task:<priority>/<provisionerId>/<workerType>` is required
+                to define a task with `<priority>`.
+              enum:
+              - highest
+              - very-high
+              - high
+              - medium
+              - low
+              - very-low
+              - lowest
+              title: Task Priority
+              type: string
+            provisionerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: provisionerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/provisionerId
+              TYPE_NAME: ProvisionerID
+              description: |
+                Unique identifier for a provisioner, that can supply specified
+                `workerType`
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Provisioner Id
+              type: string
+            requires:
+              IS_REQUIRED: true
+              PROPERTY_NAME: requires
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/requires
+              TYPE_NAME: DependencyRequirementSemantics
+              description: |
+                The tasks relation to its dependencies. This property specifies the
+                semantics of the `task.dependencies` property.
+                If `all-completed` is given the task will be scheduled when all
+                dependencies are resolved _completed_ (successful resolution).
+                If `all-resolved` is given the task will be scheduled when all dependencies
+                have been resolved, regardless of what their resolution is.
+              enum:
+              - all-completed
+              - all-resolved
+              title: Dependency Requirement Semantics
+              type: string
+            retries:
+              IS_REQUIRED: true
+              PROPERTY_NAME: retries
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/retries
+              TYPE_NAME: Retries
+              description: |
+                Number of times to retry the task in case of infrastructure issues.
+                An _infrastructure issue_ is a worker node that crashes or is shutdown,
+                these events are to be expected.
+              maximum: 49
+              minimum: 0
+              title: Retries
+              type: integer
+            routes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: routes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes
+              TYPE_NAME: TaskSpecificRoutes
+              description: |
+                List of task specific routes, AMQP messages will be CC'ed to these routes.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: routes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/routes/items
+                TYPE_NAME: TaskSpecificRoute
+                description: |
+                  A task specific route, AMQP messages will be CC'ed with a routing key
+                  matching `route.<task-specific route>`. It's possible to dot (`.`) in
+                  the task specific route to make sub-keys, etc. See the RabbitMQ
+                  [tutorial](http://www.rabbitmq.com/tutorials/tutorial-five-python.html)
+                  for examples on how to use routing-keys.
+                maxLength: 249
+                minLength: 1
+                title: Task Specific Route
+                type: string
+              maxItems: 64
+              title: Task Specific Routes
+              type: array
+              uniqueItems: true
+            schedulerId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: schedulerId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/schedulerId
+              TYPE_NAME: SchedulerIdentifier
+              description: |
+                Identifier for the scheduler that _defined_ this task, this can be an
+                identifier for a user or a service like the `"task-graph-scheduler"`.
+                Along with the `taskGroupId` this is used to form the permission scope
+                `queue:assume:scheduler-id:<schedulerId>/<taskGroupId>`,
+                this scope is necessary to _schedule_ a defined task, or _rerun_ a task.
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Scheduler Identifier
+              type: string
+            scopes:
+              IS_REQUIRED: true
+              PROPERTY_NAME: scopes
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes
+              TYPE_NAME: Scopes
+              description: |
+                List of scopes (or scope-patterns) that the task is
+                authorized to use.
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: scopes entry
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/scopes/items
+                TYPE_NAME: Scope
+                description: |
+                  A scope (or scope-patterns) which the task is
+                  authorized to use. This can be a string or a string
+                  ending with `*` which will authorize all scopes for
+                  which the string is a prefix.  Scopes must be composed of
+                  printable ASCII characters and spaces.
+                pattern: ^[\x20-\x7e]*$
+                title: Scope
+                type: string
+              title: Scopes
+              type: array
+            tags:
+              IS_REQUIRED: true
+              PROPERTY_NAME: tags
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/tags
+              TYPE_NAME: Tags
+              additionalProperties:
+                Boolean: null
+                Properties:
+                  IS_REQUIRED: false
+                  PROPERTY_NAME: ""
+                  SOURCE_URL: ""
+                  TYPE_NAME: ""
+                  maxLength: 4096
+                  type: string
+              description: |
+                Arbitrary key-value tags (only strings limited to 4k). These can be used
+                to attach informal meta-data to a task. Use this for informal tags that
+                tasks can be classified by. You can also think of strings here as
+                candidates for formal meta-data. Something like
+                `purpose: 'build' || 'test'` is a good example.
+              title: Tags
+              type: object
+            taskGroupId:
+              IS_REQUIRED: true
+              PROPERTY_NAME: taskGroupId
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/taskGroupId
+              TYPE_NAME: TaskGroupIdentifier
+              description: |
+                Identifier for a group of tasks scheduled together with this task, by
+                scheduler identified by `schedulerId`. For tasks scheduled by the
+                task-graph scheduler, this is the `taskGraphId`.  Defaults to `taskId` if
+                property isn't specified.
+              pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+              title: Task-Group Identifier
+              type: string
+            workerType:
+              IS_REQUIRED: true
+              PROPERTY_NAME: workerType
+              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/workerType
+              TYPE_NAME: WorkerType
+              description: |
+                Unique identifier for a worker-type within a specific provisioner
+              maxLength: 22
+              minLength: 1
+              pattern: ^([a-zA-Z0-9-_]*)$
+              title: Worker Type
+              type: string
+          SortedPropertyNames:
+          - created
+          - deadline
+          - dependencies
+          - expires
+          - extra
+          - metadata
+          - payload
+          - priority
+          - provisionerId
+          - requires
+          - retries
+          - routes
+          - schedulerId
+          - scopes
+          - tags
+          - taskGroupId
+          - workerType
+          SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties
+        required:
+        - provisionerId
+        - workerType
+        - schedulerId
+        - taskGroupId
+        - dependencies
+        - requires
+        - routes
+        - priority
+        - retries
+        - created
+        - deadline
+        - scopes
+        - payload
+        - metadata
+        - tags
+        - extra
+        title: Task Definition Response
+        type: object
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/task
+      TYPE_NAME: Task
+  SortedPropertyNames:
+  - status
+  - task
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties
+required:
+- task
+- status
+title: Task definition and status
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/list-workers-response.json#
 ===================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -13591,6 +18911,179 @@ title: List Workers Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items
+============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: workers entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items
+TYPE_NAME: WorkersEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    firstClaim: FirstClaim
+    latestTask: LatestTask
+    quarantineUntil: QuarantineUntil
+    workerGroup: WorkerGroup
+    workerId: WorkerID
+  Properties:
+    firstClaim:
+      IS_REQUIRED: true
+      PROPERTY_NAME: firstClaim
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/firstClaim
+      TYPE_NAME: FirstTaskClaimed
+      description: |
+        Date of the first time this worker claimed a task.
+      format: date-time
+      title: First task claimed
+      type: string
+    latestTask:
+      IS_REQUIRED: false
+      PROPERTY_NAME: latestTask
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
+      TYPE_NAME: MostRecentTask
+      additionalProperties:
+        Boolean: false
+        Properties: null
+      description: |
+        The most recent claimed task
+      properties:
+        MemberNames:
+          runId: RunID
+          taskId: TaskID
+        Properties:
+          runId:
+            IS_REQUIRED: true
+            PROPERTY_NAME: runId
+            SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/runId
+            TYPE_NAME: RunIdentifier
+            description: |
+              Id of this task run, `run-id`s always starts from `0`
+            maximum: 1000
+            minimum: 0
+            title: Run Identifier
+            type: integer
+          taskId:
+            IS_REQUIRED: true
+            PROPERTY_NAME: taskId
+            SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/taskId
+            TYPE_NAME: TaskIdentifier
+            description: |
+              Unique task identifier, this is UUID encoded as
+              [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+              stripped of `=` padding.
+            pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+            title: Task Identifier
+            type: string
+        SortedPropertyNames:
+        - runId
+        - taskId
+        SourceURL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties
+      required:
+      - taskId
+      - runId
+      title: Most Recent Task
+      type: object
+    quarantineUntil:
+      IS_REQUIRED: false
+      PROPERTY_NAME: quarantineUntil
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/quarantineUntil
+      TYPE_NAME: WorkerQuarantine
+      description: |
+        Quarantining a worker allows the machine to remain alive but not accept jobs.
+        Once the quarantineUntil time has elapsed, the worker resumes accepting jobs.
+        Note that a quarantine can be lifted by setting `quarantineUntil` to the present time (or
+        somewhere in the past).
+      format: date-time
+      title: Worker Quarantine
+      type: string
+    workerGroup:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerGroup
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerGroup
+      TYPE_NAME: WorkerGroup
+      description: |
+        Identifier for the worker group containing this worker.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      type: string
+    workerId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: workerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerId
+      TYPE_NAME: WorkerID
+      description: |
+        Identifier for this worker (unique within this worker group).
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      type: string
+  SortedPropertyNames:
+  - firstClaim
+  - latestTask
+  - quarantineUntil
+  - workerGroup
+  - workerId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties
+required:
+- workerGroup
+- workerId
+- firstClaim
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
+==================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: latestTask
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
+TYPE_NAME: MostRecentTask
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  The most recent claimed task
+properties:
+  MemberNames:
+    runId: RunID
+    taskId: TaskID
+  Properties:
+    runId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/runId
+      TYPE_NAME: RunIdentifier
+      description: |
+        Id of this task run, `run-id`s always starts from `0`
+      maximum: 1000
+      minimum: 0
+      title: Run Identifier
+      type: integer
+    taskId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: taskId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/taskId
+      TYPE_NAME: TaskIdentifier
+      description: |
+        Unique task identifier, this is UUID encoded as
+        [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+        stripped of `=` padding.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      title: Task Identifier
+      type: string
+  SortedPropertyNames:
+  - runId
+  - taskId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties
+required:
+- taskId
+- runId
+title: Most Recent Task
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#
 =======================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -13734,6 +19227,103 @@ properties:
 required:
 - workerTypes
 title: List Worker-Types Response
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items
+====================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: workerTypes entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items
+TYPE_NAME: WorkerTypesEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    description: Description
+    expires: Expires
+    lastDateActive: LastDateActive
+    provisionerId: ProvisionerID
+    stability: Stability
+    workerType: WorkerType
+  Properties:
+    description:
+      IS_REQUIRED: false
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/description
+      TYPE_NAME: Description
+      description: |
+        Description of the worker-type.
+      title: Description
+      type: string
+    expires:
+      IS_REQUIRED: false
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/expires
+      TYPE_NAME: WorkerTypeExpiration
+      description: |
+        Date and time after which the worker-type will be automatically
+        deleted by the queue.
+      format: date-time
+      title: Worker-type Expiration
+      type: string
+    lastDateActive:
+      IS_REQUIRED: false
+      PROPERTY_NAME: lastDateActive
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/lastDateActive
+      TYPE_NAME: WorkerTypeLastDateActive
+      description: |
+        Date and time where the worker-type was last seen active
+      format: date-time
+      title: Worker-type Last Date Active
+      type: string
+    provisionerId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: provisionerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/provisionerId
+      TYPE_NAME: ProvisionerID
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Provisioner ID
+      type: string
+    stability:
+      IS_REQUIRED: false
+      PROPERTY_NAME: stability
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/stability
+      TYPE_NAME: Stability
+      description: |
+        This is the stability of the worker-type. Accepted values:
+         * `experimental`
+         * `stable`
+         * `deprecated`
+      enum:
+      - experimental
+      - stable
+      - deprecated
+      title: Stability
+      type: string
+    workerType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerType
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/workerType
+      TYPE_NAME: WorkerTypeName
+      description: |
+        WorkerType name.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: WorkerType name
+      type: string
+  SortedPropertyNames:
+  - description
+  - expires
+  - lastDateActive
+  - provisionerId
+  - stability
+  - workerType
+  SourceURL: http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties
 type: object
 
 
@@ -13925,6 +19515,78 @@ required:
 - queues
 - expires
 title: Poll Task Urls Response
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items
+=============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: queues entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items
+TYPE_NAME: SignedURLsForAQueue
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Object holding two signed URLs for an azure queue, one for fetching
+  messages, and another for deleting messages. Remember to `claimTask`
+  before deleting the message, and delete message even if the `claimTask`
+  operation fails with a 400 status code. Don't delete it on other status
+  codes!
+properties:
+  MemberNames:
+    signedDeleteUrl: SignedDeleteURL
+    signedPollUrl: SignedPollURL
+  Properties:
+    signedDeleteUrl:
+      IS_REQUIRED: true
+      PROPERTY_NAME: signedDeleteUrl
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedDeleteUrl
+      TYPE_NAME: SignedDeleteMessageURL
+      description: |
+        Signed URL to delete messages that have been received using the
+        `signedPollUrl`. You **must** do this to avoid receiving the same
+        message again.
+        To use this URL you must substitute `{{messageId}}` and
+        `{{popReceipt}}` with `MessageId` and `PopReceipt` from the XML
+        response the `signedPollUrl` gave you. It is important that you
+        `encodeURIComponent` both `MessageId` and `PopReceipt` prior to
+        substitution, otherwise you will experience intermittent failures!
+        Note this URL only works with `DELETE` request.
+      pattern: ^https://
+      title: Signed Delete Message URL
+      type: string
+    signedPollUrl:
+      IS_REQUIRED: true
+      PROPERTY_NAME: signedPollUrl
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedPollUrl
+      TYPE_NAME: SignedGetMessageURL
+      description: |
+        Signed URL to get message from the Azure Queue Storage queue,
+        that holds messages for the given `provisionerId` and `workerType`.
+        Note that this URL returns XML, see documentation for the Azure
+        Queue Storage
+        [REST API](http://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
+        for details.
+        When you have a message you can use `claimTask` to claim the task.
+        You will need to parse the XML response and base64 decode and
+        JSON parse the `MessageText`.
+        After you have called `claimTask` you **must** us the
+        `signedDeleteUrl` to delete the message.
+        **Remark**, you are allowed to append `&numofmessages=N`,
+        where N < 32, to the URLs if you wish to obtain more than one
+        message at the time.
+      format: uri
+      title: Signed Get Message URL
+      type: string
+  SortedPropertyNames:
+  - signedDeleteUrl
+  - signedPollUrl
+  SourceURL: http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties
+required:
+- signedPollUrl
+- signedDeleteUrl
+title: Signed URLs for a queue
 type: object
 
 
@@ -14610,6 +20272,49 @@ required:
 - contentSha256
 - contentLength
 title: Blob Artifact Request
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items
+===================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: parts entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items
+TYPE_NAME: PartsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    sha256: Sha256
+    size: Size
+  Properties:
+    sha256:
+      IS_REQUIRED: false
+      PROPERTY_NAME: sha256
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/sha256
+      TYPE_NAME: Sha256
+      description: |
+        The sha256 hash of the part.
+      maxLength: 64
+      minLength: 64
+      pattern: ^[a-fA-F0-9]{64}$
+      type: string
+    size:
+      IS_REQUIRED: false
+      PROPERTY_NAME: size
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/size
+      TYPE_NAME: Size
+      description: |
+        The number of bytes in this part.  Keep in mind for S3 that
+        all but the last part must be minimum 5MB and the maximum for
+        a single part is 5GB.  The overall size may not exceed 5TB
+      minimum: 0
+      type: integer
+  SortedPropertyNames:
+  - sha256
+  - size
+  SourceURL: http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties
 type: object
 
 
@@ -15345,6 +21050,63 @@ required:
 title: Blob Artifact Response
 
 
+http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items
+=======================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: requests entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items
+TYPE_NAME: RequestsEntry
+properties:
+  MemberNames:
+    headers: Headers
+    method: Method
+    url: URL
+  Properties:
+    headers:
+      IS_REQUIRED: false
+      PROPERTY_NAME: headers
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/headers
+      TYPE_NAME: Headers
+      additionalProperties:
+        Boolean: null
+        Properties:
+          IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: ""
+          TYPE_NAME: ""
+          type: string
+      description: Headers of request
+      type: object
+    method:
+      IS_REQUIRED: false
+      PROPERTY_NAME: method
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/method
+      TYPE_NAME: Method
+      description: HTTP 1.1 method of request
+      enum:
+      - GET
+      - POST
+      - PUT
+      - DELETE
+      - OPTIONS
+      - HEAD
+      - PATCH
+      type: string
+    url:
+      IS_REQUIRED: false
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/url
+      TYPE_NAME: URL
+      description: URL of request
+      type: string
+  SortedPropertyNames:
+  - headers
+  - method
+  - url
+  SourceURL: http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[1]
 =============================================================================
 IS_REQUIRED: false
@@ -15589,130 +21351,164 @@ properties:
     stability: Stability
   Properties:
     actions:
+      $ref: http://schemas.taskcluster.net/queue/v1/actions.json#
       IS_REQUIRED: true
       PROPERTY_NAME: actions
-      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions
-      TYPE_NAME: Actions
-      items:
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
         IS_REQUIRED: false
-        PROPERTY_NAME: actions entry
-        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items
-        TYPE_NAME: Actions1
-        additionalProperties:
-          Boolean: false
-          Properties: null
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#
+        TYPE_NAME: Actions3
         description: |
-          Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
-          Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
-          used by the front-end to know where to display the action. For example, `context=worker`
-          will display the action on the worker explorer.
+          See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+        id: http://schemas.taskcluster.net/queue/v1/actions.json#
+        items:
+          IS_REQUIRED: false
+          PROPERTY_NAME: ' entry'
+          SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+          TYPE_NAME: Actions4
+          additionalProperties:
+            Boolean: false
+            Properties: null
+          description: |
+            Actions provide a generic mechanism to expose additional features of a
+            provisioner, worker type, or worker to Taskcluster clients.
 
-          _Note: The request will be signed with the user's Taskcluster credentials._
-        properties:
-          MemberNames:
-            context: Context
-            description: Description
-            method: Method
-            name: Name
-            title: Title
-            url: URL
-          Properties:
-            context:
-              IS_REQUIRED: true
-              PROPERTY_NAME: context
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/context
-              TYPE_NAME: Context
-              description: |
-                Actions have a "context" that is one of provisioner, worker-type,
-                or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
+            An action is comprised of metadata describing the feature it exposes,
+            together with a webhook for triggering it.
 
-                | `context`   | Page displayed        |
-                |-------------|-----------------------|
-                | provisioner | Provisioner Explorer  |
-                | worker-type | Workers Explorer      |
-                | worker      | Worker Explorer       |
-              enum:
-              - provisioner
-              - worker-type
-              - worker
-              title: Context
-              type: string
-            description:
-              IS_REQUIRED: true
-              PROPERTY_NAME: description
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/description
-              TYPE_NAME: Description
-              description: |
-                Description of the provisioner.
-              title: Description
-              type: string
-            method:
-              IS_REQUIRED: true
-              PROPERTY_NAME: method
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/method
-              TYPE_NAME: Method
-              description: |
-                Method to indicate the desired action to be performed for a given resource.
-              enum:
-              - POST
-              - PUT
-              - DELETE
-              - PATCH
-              title: Method
-              type: string
-            name:
-              IS_REQUIRED: true
-              PROPERTY_NAME: name
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/name
-              TYPE_NAME: Name
-              description: |
-                Short names for things like logging/error messages.
-              title: Name
-              type: string
-            title:
-              IS_REQUIRED: true
-              PROPERTY_NAME: title
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/title
-              TYPE_NAME: Title
-              description: |
-                Appropriate title for any sort of Modal prompt.
+            The Taskcluster tools site, for example, retrieves actions when displaying
+            provisioners, worker types and workers. It presents the provisioner/worker
+            type/worker specific actions to the user. When the user triggers an action,
+            the web client takes the registered webhook, substitutes parameters into the
+            URL (see `url`), signs the requests with the Taskcluster credentials of the
+            user operating the web interface, and issues the HTTP request.
+
+            The level to which the action relates (provisioner, worker type, worker) is
+            called the action context. All actions, regardless of the action contexts,
+            are registered against the provisioner when calling
+            `queue.declareProvisioner`.
+
+            The action context is used by the web client to determine where in the web
+            interface to present the action to the user as follows:
+
+            | `context`   | Tool where action is displayed |
+            |-------------|--------------------------------|
+            | provisioner | Provisioner Explorer           |
+            | worker-type | Workers Explorer               |
+            | worker      | Worker Explorer                |
+
+            See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+            for more information.
+          properties:
+            MemberNames:
+              context: Context
+              description: Description
+              method: Method
+              name: Name
               title: Title
-            url:
-              IS_REQUIRED: true
-              PROPERTY_NAME: url
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/url
-              TYPE_NAME: URL
-              description: |
-                When an action is triggered, a request is made using the `url` and `method`.
-                Depending on the `context`, the following parameters will be substituted in the url:
+              url: URL
+            Properties:
+              context:
+                IS_REQUIRED: true
+                PROPERTY_NAME: context
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+                TYPE_NAME: Context
+                description: |
+                  Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+                  which it applies to. `context` is used by the front-end to know where to display the action.
 
-                | `context`   | Path parameters                                          |
-                |-------------|----------------------------------------------------------|
-                | provisioner | <provisionerId>                                          |
-                | worker-type | <provisionerId>, <workerType>                            |
-                | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+                  | `context`   | Page displayed        |
+                  |-------------|-----------------------|
+                  | provisioner | Provisioner Explorer  |
+                  | worker-type | Workers Explorer      |
+                  | worker      | Worker Explorer       |
+                enum:
+                - provisioner
+                - worker-type
+                - worker
+                title: Context
+                type: string
+              description:
+                IS_REQUIRED: true
+                PROPERTY_NAME: description
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+                TYPE_NAME: Description
+                description: |
+                  Description of the provisioner.
+                title: Description
+                type: string
+              method:
+                IS_REQUIRED: true
+                PROPERTY_NAME: method
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+                TYPE_NAME: Method
+                description: |
+                  Method to indicate the desired action to be performed for a given resource.
+                enum:
+                - POST
+                - PUT
+                - DELETE
+                - PATCH
+                title: Method
+                type: string
+              name:
+                IS_REQUIRED: true
+                PROPERTY_NAME: name
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+                TYPE_NAME: Name
+                description: |
+                  Short names for things like logging/error messages.
+                title: Name
+                type: string
+              title:
+                IS_REQUIRED: true
+                PROPERTY_NAME: title
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+                TYPE_NAME: Title
+                description: |
+                  Appropriate title for any sort of Modal prompt.
+                title: Title
+              url:
+                IS_REQUIRED: true
+                PROPERTY_NAME: url
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+                TYPE_NAME: URL
+                description: |
+                  When an action is triggered, a request is made using the `url` and `method`.
+                  Depending on the `context`, the following parameters will be substituted in the url:
 
-                _Note: The request needs to be signed with the user's Taskcluster credentials._
-              title: URL
-              type: string
-          SortedPropertyNames:
-          - context
-          - description
-          - method
+                  | `context`   | Path parameters                                          |
+                  |-------------|----------------------------------------------------------|
+                  | provisioner | <provisionerId>                                          |
+                  | worker-type | <provisionerId>, <workerType>                            |
+                  | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+                  _Note: The request needs to be signed with the user's Taskcluster credentials._
+                title: URL
+                type: string
+            SortedPropertyNames:
+            - context
+            - description
+            - method
+            - name
+            - title
+            - url
+            SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+          required:
           - name
           - title
+          - context
           - url
-          SourceURL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties
-        required:
-        - name
-        - title
-        - context
-        - url
-        - method
-        - description
+          - method
+          - description
+          title: Actions
+          type: object
         title: Actions
-        type: object
-      type: array
+        type: array
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions
+      TYPE_NAME: Actions
     description:
       IS_REQUIRED: true
       PROPERTY_NAME: description
@@ -15945,7 +21741,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: credentials
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials
-      TYPE_NAME: Credentials
+      TYPE_NAME: Credentials1
       additionalProperties:
         Boolean: false
         Properties: null
@@ -16851,6 +22647,77 @@ title: Task Claim Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials
+========================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials
+TYPE_NAME: Credentials1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Temporary credentials granting `task.scopes` and the scope:
+  `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+  the task, upload artifacts and report task resolution.
+
+  The temporary credentials are set to expire after `takenUntil`. They
+  won't expire exactly at `takenUntil` but shortly after, hence, requests
+  coming close `takenUntil` won't have problems even if there is a little
+  clock drift.
+
+  Workers should use these credentials when making requests on behalf of
+  a task. This includes requests to create artifacts, reclaiming the task
+  reporting the task `completed`, `failed` or `exception`.
+
+  Note, a new set of temporary credentials is issued when the worker
+  reclaims the task.
+properties:
+  MemberNames:
+    accessToken: AccessToken
+    certificate: Certificate
+    clientId: ClientID
+  Properties:
+    accessToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessToken
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/accessToken
+      TYPE_NAME: AccessToken
+      description: |
+        The `accessToken` for the temporary credentials.
+      minLength: 1
+      type: string
+    certificate:
+      IS_REQUIRED: true
+      PROPERTY_NAME: certificate
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/certificate
+      TYPE_NAME: Certificate
+      description: |
+        The `certificate` for the temporary credentials, these are required
+        for the temporary credentials to work.
+      minLength: 1
+      type: string
+    clientId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: clientId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/clientId
+      TYPE_NAME: ClientID
+      description: |
+        The `clientId` for the temporary credentials.
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - accessToken
+  - certificate
+  - clientId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties
+required:
+- clientId
+- accessToken
+- certificate
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/task-exception-request.json#
 ====================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -16952,7 +22819,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: credentials
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials
-      TYPE_NAME: Credentials
+      TYPE_NAME: Credentials2
       additionalProperties:
         Boolean: false
         Properties: null
@@ -17437,6 +23304,77 @@ required:
 - takenUntil
 - credentials
 title: Task Reclaim Response
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials
+==========================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: credentials
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials
+TYPE_NAME: Credentials2
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Temporary credentials granting `task.scopes` and the scope:
+  `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+  the task, upload artifacts and report task resolution.
+
+  The temporary credentials are set to expire after `takenUntil`. They
+  won't expire exactly at `takenUntil` but shortly after, hence, requests
+  coming close `takenUntil` won't have problems even if there is a little
+  clock drift.
+
+  Workers should use these credentials when making requests on behalf of
+  a task. This includes requests to create artifacts, reclaiming the task
+  reporting the task `completed`, `failed` or `exception`.
+
+  Note, a new set of temporary credentials is issued when the worker
+  reclaims the task.
+properties:
+  MemberNames:
+    accessToken: AccessToken
+    certificate: Certificate
+    clientId: ClientID
+  Properties:
+    accessToken:
+      IS_REQUIRED: true
+      PROPERTY_NAME: accessToken
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/accessToken
+      TYPE_NAME: AccessToken
+      description: |
+        The `accessToken` for the temporary credentials.
+      minLength: 1
+      type: string
+    certificate:
+      IS_REQUIRED: true
+      PROPERTY_NAME: certificate
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/certificate
+      TYPE_NAME: Certificate
+      description: |
+        The `certificate` for the temporary credentials, these are required
+        for the temporary credentials to work.
+      minLength: 1
+      type: string
+    clientId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: clientId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/clientId
+      TYPE_NAME: ClientID
+      description: |
+        The `clientId` for the temporary credentials.
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - accessToken
+  - certificate
+  - clientId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties
+required:
+- clientId
+- accessToken
+- certificate
 type: object
 
 
@@ -18189,6 +24127,194 @@ title: Task Status Structure
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+===============================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: runs entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+TYPE_NAME: RunInformation
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  JSON object with information about a run
+properties:
+  MemberNames:
+    reasonCreated: ReasonCreated
+    reasonResolved: ReasonResolved
+    resolved: Resolved
+    runId: RunID
+    scheduled: Scheduled
+    started: Started
+    state: State
+    takenUntil: TakenUntil
+    workerGroup: WorkerGroup
+    workerId: WorkerID
+  Properties:
+    reasonCreated:
+      IS_REQUIRED: true
+      PROPERTY_NAME: reasonCreated
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+      TYPE_NAME: ReasonCreated
+      description: |
+        Reason for the creation of this run,
+        **more reasons may be added in the future**.
+      enum:
+      - scheduled
+      - retry
+      - task-retry
+      - rerun
+      - exception
+      title: Reason Created
+      type: string
+    reasonResolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: reasonResolved
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+      TYPE_NAME: ReasonResolved
+      description: |
+        Reason that run was resolved, this is mainly
+        useful for runs resolved as `exception`.
+        Note, **more reasons may be added in the future**, also this
+        property is only available after the run is resolved. Some of these
+        reasons, notably `intermittent-task`, `worker-shutdown`, and
+        `claim-expired`, will trigger an automatic retry of the task.
+      enum:
+      - completed
+      - failed
+      - deadline-exceeded
+      - canceled
+      - superseded
+      - claim-expired
+      - worker-shutdown
+      - malformed-payload
+      - resource-unavailable
+      - internal-error
+      - intermittent-task
+      title: Reason Resolved
+      type: string
+    resolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: resolved
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+      TYPE_NAME: Resolved
+      description: |
+        Date-time at which this run was resolved, ie. when the run changed
+        state from `running` to either `completed`, `failed` or `exception`.
+        This property is only present after the run as been resolved.
+      format: date-time
+      title: Resolved
+      type: string
+    runId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+      TYPE_NAME: RunIdentifier
+      description: |
+        Id of this task run, `run-id`s always starts from `0`
+      maximum: 1000
+      minimum: 0
+      title: Run Identifier
+      type: integer
+    scheduled:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scheduled
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+      TYPE_NAME: Scheduled
+      description: |
+        Date-time at which this run was scheduled, ie. when the run was
+        created in state `pending`.
+      format: date-time
+      title: Scheduled
+      type: string
+    started:
+      IS_REQUIRED: false
+      PROPERTY_NAME: started
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+      TYPE_NAME: Started
+      description: |
+        Date-time at which this run was claimed, ie. when the run changed
+        state from `pending` to `running`. This property is only present
+        after the run has been claimed.
+      format: date-time
+      title: Started
+      type: string
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+      TYPE_NAME: RunState
+      description: |
+        State of this run
+      enum:
+      - pending
+      - running
+      - completed
+      - failed
+      - exception
+      title: Run State
+      type: string
+    takenUntil:
+      IS_REQUIRED: false
+      PROPERTY_NAME: takenUntil
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+      TYPE_NAME: TakenUntil
+      description: |
+        Time at which the run expires and is resolved as `failed`, if the
+        run isn't reclaimed. Note, only present after the run has been
+        claimed.
+      format: date-time
+      title: Taken Until
+      type: string
+    workerGroup:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerGroup
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+      TYPE_NAME: WorkerGroup
+      description: |
+        Identifier for group that worker who executes this run is a part of,
+        this identifier is mainly used for efficient routing.
+        Note, this property is only present after the run is claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Group
+      type: string
+    workerId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+      TYPE_NAME: WorkerIdentifier
+      description: |
+        Identifier for worker evaluating this run within given
+        `workerGroup`. Note, this property is only available after the run
+        has been claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Identifier
+      type: string
+  SortedPropertyNames:
+  - reasonCreated
+  - reasonResolved
+  - resolved
+  - runId
+  - scheduled
+  - started
+  - state
+  - takenUntil
+  - workerGroup
+  - workerId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties
+required:
+- runId
+- state
+- reasonCreated
+- scheduled
+title: Run Information
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/task.json#
 ==================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -18602,6 +24728,87 @@ title: Task Definition Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+======================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: metadata
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+TYPE_NAME: MetaData
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Required task metadata
+properties:
+  MemberNames:
+    description: Description
+    name: Name
+    owner: Owner
+    source: Source
+  Properties:
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
+      TYPE_NAME: Description
+      description: |
+        Human readable description of the task, please **explain** what the
+        task does. A few lines of documentation is not going to hurt you.
+      maxLength: 32768
+      title: Description
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
+      TYPE_NAME: Name
+      description: |
+        Human readable name of task, used to very briefly given an idea about
+        what the task does.
+      maxLength: 255
+      title: Name
+      type: string
+    owner:
+      IS_REQUIRED: true
+      PROPERTY_NAME: owner
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
+      TYPE_NAME: Owner
+      description: |
+        E-mail of person who caused this task, e.g. the person who did
+        `hg push`. The person we should contact to ask why this task is here.
+      format: email
+      maxLength: 255
+      title: Owner
+      type: string
+    source:
+      IS_REQUIRED: true
+      PROPERTY_NAME: source
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
+      TYPE_NAME: Source
+      description: |
+        Link to source of this task, should specify a file, revision and
+        repository. This should be place someone can go an do a git/hg blame
+        to who came up with recipe for this task.
+      format: uri
+      maxLength: 4096
+      pattern: ^https?://
+      title: Source
+      type: string
+  SortedPropertyNames:
+  - description
+  - name
+  - owner
+  - source
+  SourceURL: http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties
+required:
+- name
+- description
+- owner
+- source
+title: Meta-data
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#
 ========================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -18623,130 +24830,164 @@ properties:
     stability: Stability
   Properties:
     actions:
+      $ref: http://schemas.taskcluster.net/queue/v1/actions.json#
       IS_REQUIRED: false
       PROPERTY_NAME: actions
-      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions
-      TYPE_NAME: Actions
-      items:
+      REF_SUBSCHEMA:
+        $schema: http://json-schema.org/draft-06/schema#
         IS_REQUIRED: false
-        PROPERTY_NAME: actions entry
-        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items
-        TYPE_NAME: Actions1
-        additionalProperties:
-          Boolean: false
-          Properties: null
+        PROPERTY_NAME: ""
+        SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#
+        TYPE_NAME: Actions3
         description: |
-          Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
-          Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
-          used by the front-end to know where to display the action. For example, `context=worker`
-          will display the action on the worker explorer.
+          See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+        id: http://schemas.taskcluster.net/queue/v1/actions.json#
+        items:
+          IS_REQUIRED: false
+          PROPERTY_NAME: ' entry'
+          SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items
+          TYPE_NAME: Actions4
+          additionalProperties:
+            Boolean: false
+            Properties: null
+          description: |
+            Actions provide a generic mechanism to expose additional features of a
+            provisioner, worker type, or worker to Taskcluster clients.
 
-          _Note: The request will be signed with the user's Taskcluster credentials._
-        properties:
-          MemberNames:
-            context: Context
-            description: Description
-            method: Method
-            name: Name
-            title: Title
-            url: URL
-          Properties:
-            context:
-              IS_REQUIRED: true
-              PROPERTY_NAME: context
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/context
-              TYPE_NAME: Context
-              description: |
-                Actions have a "context" that is one of provisioner, worker-type,
-                or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
+            An action is comprised of metadata describing the feature it exposes,
+            together with a webhook for triggering it.
 
-                | `context`   | Page displayed        |
-                |-------------|-----------------------|
-                | provisioner | Provisioner Explorer  |
-                | worker-type | Workers Explorer      |
-                | worker      | Worker Explorer       |
-              enum:
-              - provisioner
-              - worker-type
-              - worker
-              title: Context
-              type: string
-            description:
-              IS_REQUIRED: true
-              PROPERTY_NAME: description
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/description
-              TYPE_NAME: Description
-              description: |
-                Description of the provisioner.
-              title: Description
-              type: string
-            method:
-              IS_REQUIRED: true
-              PROPERTY_NAME: method
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/method
-              TYPE_NAME: Method
-              description: |
-                Method to indicate the desired action to be performed for a given resource.
-              enum:
-              - POST
-              - PUT
-              - DELETE
-              - PATCH
-              title: Method
-              type: string
-            name:
-              IS_REQUIRED: true
-              PROPERTY_NAME: name
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/name
-              TYPE_NAME: Name
-              description: |
-                Short names for things like logging/error messages.
-              title: Name
-              type: string
-            title:
-              IS_REQUIRED: true
-              PROPERTY_NAME: title
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/title
-              TYPE_NAME: Title
-              description: |
-                Appropriate title for any sort of Modal prompt.
+            The Taskcluster tools site, for example, retrieves actions when displaying
+            provisioners, worker types and workers. It presents the provisioner/worker
+            type/worker specific actions to the user. When the user triggers an action,
+            the web client takes the registered webhook, substitutes parameters into the
+            URL (see `url`), signs the requests with the Taskcluster credentials of the
+            user operating the web interface, and issues the HTTP request.
+
+            The level to which the action relates (provisioner, worker type, worker) is
+            called the action context. All actions, regardless of the action contexts,
+            are registered against the provisioner when calling
+            `queue.declareProvisioner`.
+
+            The action context is used by the web client to determine where in the web
+            interface to present the action to the user as follows:
+
+            | `context`   | Tool where action is displayed |
+            |-------------|--------------------------------|
+            | provisioner | Provisioner Explorer           |
+            | worker-type | Workers Explorer               |
+            | worker      | Worker Explorer                |
+
+            See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+            for more information.
+          properties:
+            MemberNames:
+              context: Context
+              description: Description
+              method: Method
+              name: Name
               title: Title
-            url:
-              IS_REQUIRED: true
-              PROPERTY_NAME: url
-              SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/url
-              TYPE_NAME: URL
-              description: |
-                When an action is triggered, a request is made using the `url` and `method`.
-                Depending on the `context`, the following parameters will be substituted in the url:
+              url: URL
+            Properties:
+              context:
+                IS_REQUIRED: true
+                PROPERTY_NAME: context
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+                TYPE_NAME: Context
+                description: |
+                  Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+                  which it applies to. `context` is used by the front-end to know where to display the action.
 
-                | `context`   | Path parameters                                          |
-                |-------------|----------------------------------------------------------|
-                | provisioner | <provisionerId>                                          |
-                | worker-type | <provisionerId>, <workerType>                            |
-                | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+                  | `context`   | Page displayed        |
+                  |-------------|-----------------------|
+                  | provisioner | Provisioner Explorer  |
+                  | worker-type | Workers Explorer      |
+                  | worker      | Worker Explorer       |
+                enum:
+                - provisioner
+                - worker-type
+                - worker
+                title: Context
+                type: string
+              description:
+                IS_REQUIRED: true
+                PROPERTY_NAME: description
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+                TYPE_NAME: Description
+                description: |
+                  Description of the provisioner.
+                title: Description
+                type: string
+              method:
+                IS_REQUIRED: true
+                PROPERTY_NAME: method
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+                TYPE_NAME: Method
+                description: |
+                  Method to indicate the desired action to be performed for a given resource.
+                enum:
+                - POST
+                - PUT
+                - DELETE
+                - PATCH
+                title: Method
+                type: string
+              name:
+                IS_REQUIRED: true
+                PROPERTY_NAME: name
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+                TYPE_NAME: Name
+                description: |
+                  Short names for things like logging/error messages.
+                title: Name
+                type: string
+              title:
+                IS_REQUIRED: true
+                PROPERTY_NAME: title
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+                TYPE_NAME: Title
+                description: |
+                  Appropriate title for any sort of Modal prompt.
+                title: Title
+              url:
+                IS_REQUIRED: true
+                PROPERTY_NAME: url
+                SOURCE_URL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+                TYPE_NAME: URL
+                description: |
+                  When an action is triggered, a request is made using the `url` and `method`.
+                  Depending on the `context`, the following parameters will be substituted in the url:
 
-                _Note: The request needs to be signed with the user's Taskcluster credentials._
-              title: URL
-              type: string
-          SortedPropertyNames:
-          - context
-          - description
-          - method
+                  | `context`   | Path parameters                                          |
+                  |-------------|----------------------------------------------------------|
+                  | provisioner | <provisionerId>                                          |
+                  | worker-type | <provisionerId>, <workerType>                            |
+                  | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+                  _Note: The request needs to be signed with the user's Taskcluster credentials._
+                title: URL
+                type: string
+            SortedPropertyNames:
+            - context
+            - description
+            - method
+            - name
+            - title
+            - url
+            SourceURL: http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties
+          required:
           - name
           - title
+          - context
           - url
-          SourceURL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties
-        required:
-        - name
-        - title
-        - context
-        - url
-        - method
-        - description
+          - method
+          - description
+          title: Actions
+          type: object
         title: Actions
-        type: object
-      type: array
+        type: array
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions
+      TYPE_NAME: Actions
     description:
       IS_REQUIRED: false
       PROPERTY_NAME: description
@@ -18921,22 +25162,45 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: actions
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions
-      TYPE_NAME: Actions
+      TYPE_NAME: WorkerActions
       items:
         IS_REQUIRED: false
         PROPERTY_NAME: actions entry
         SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items
-        TYPE_NAME: Actions1
+        TYPE_NAME: Actions2
         additionalProperties:
           Boolean: false
           Properties: null
         description: |
-          Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
-          Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
-          used by the front-end to know where to display the action. For example, `context=worker`
-          will display the action on the worker explorer.
+          Actions provide a generic mechanism to expose additional features of a
+          provisioner, worker type, or worker to Taskcluster clients.
 
-          _Note: The request will be signed with the user's Taskcluster credentials._
+          An action is comprised of metadata describing the feature it exposes,
+          together with a webhook for triggering it.
+
+          The Taskcluster tools site, for example, retrieves actions when displaying
+          provisioners, worker types and workers. It presents the provisioner/worker
+          type/worker specific actions to the user. When the user triggers an action,
+          the web client takes the registered webhook, substitutes parameters into the
+          URL (see `url`), signs the requests with the Taskcluster credentials of the
+          user operating the web interface, and issues the HTTP request.
+
+          The level to which the action relates (provisioner, worker type, worker) is
+          called the action context. All actions, regardless of the action contexts,
+          are registered against the provisioner when calling
+          `queue.declareProvisioner`.
+
+          The action context is used by the web client to determine where in the web
+          interface to present the action to the user as follows:
+
+          | `context`   | Tool where action is displayed |
+          |-------------|--------------------------------|
+          | provisioner | Provisioner Explorer           |
+          | worker-type | Workers Explorer               |
+          | worker      | Worker Explorer                |
+
+          See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+          for more information.
         properties:
           MemberNames:
             context: Context
@@ -18952,14 +25216,7 @@ properties:
               SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/context
               TYPE_NAME: Context
               description: |
-                Actions have a "context" that is one of provisioner, worker-type,
-                or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-
-                | `context`   | Page displayed        |
-                |-------------|-----------------------|
-                | provisioner | Provisioner Explorer  |
-                | worker-type | Workers Explorer      |
-                | worker      | Worker Explorer       |
+                Only actions with the context `worker` are included.
               enum:
               - worker
               title: Context
@@ -19039,6 +25296,7 @@ properties:
         - description
         title: Actions
         type: object
+      title: Worker Actions
       type: array
     expires:
       IS_REQUIRED: true
@@ -19196,6 +25454,186 @@ title: Worker Response
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items
+======================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: actions entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items
+TYPE_NAME: Actions2
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Actions provide a generic mechanism to expose additional features of a
+  provisioner, worker type, or worker to Taskcluster clients.
+
+  An action is comprised of metadata describing the feature it exposes,
+  together with a webhook for triggering it.
+
+  The Taskcluster tools site, for example, retrieves actions when displaying
+  provisioners, worker types and workers. It presents the provisioner/worker
+  type/worker specific actions to the user. When the user triggers an action,
+  the web client takes the registered webhook, substitutes parameters into the
+  URL (see `url`), signs the requests with the Taskcluster credentials of the
+  user operating the web interface, and issues the HTTP request.
+
+  The level to which the action relates (provisioner, worker type, worker) is
+  called the action context. All actions, regardless of the action contexts,
+  are registered against the provisioner when calling
+  `queue.declareProvisioner`.
+
+  The action context is used by the web client to determine where in the web
+  interface to present the action to the user as follows:
+
+  | `context`   | Tool where action is displayed |
+  |-------------|--------------------------------|
+  | provisioner | Provisioner Explorer           |
+  | worker-type | Workers Explorer               |
+  | worker      | Worker Explorer                |
+
+  See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+  for more information.
+properties:
+  MemberNames:
+    context: Context
+    description: Description
+    method: Method
+    name: Name
+    title: Title
+    url: URL
+  Properties:
+    context:
+      IS_REQUIRED: true
+      PROPERTY_NAME: context
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/context
+      TYPE_NAME: Context
+      description: |
+        Only actions with the context `worker` are included.
+      enum:
+      - worker
+      title: Context
+      type: string
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/description
+      TYPE_NAME: Description
+      description: |
+        Description of the provisioner.
+      title: Description
+      type: string
+    method:
+      IS_REQUIRED: true
+      PROPERTY_NAME: method
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/method
+      TYPE_NAME: Method
+      description: |
+        Method to indicate the desired action to be performed for a given resource.
+      enum:
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+      title: Method
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/name
+      TYPE_NAME: Name
+      description: |
+        Short names for things like logging/error messages.
+      title: Name
+      type: string
+    title:
+      IS_REQUIRED: true
+      PROPERTY_NAME: title
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/title
+      TYPE_NAME: Title
+      description: |
+        Appropriate title for any sort of Modal prompt.
+      title: Title
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/url
+      TYPE_NAME: URL
+      description: |
+        When an action is triggered, a request is made using the `url` and `method`.
+        Depending on the `context`, the following parameters will be substituted in the url:
+
+        | `context`   | Path parameters                                          |
+        |-------------|----------------------------------------------------------|
+        | provisioner | <provisionerId>                                          |
+        | worker-type | <provisionerId>, <workerType>                            |
+        | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+        _Note: The request needs to be signed with the user's Taskcluster credentials._
+      title: URL
+      type: string
+  SortedPropertyNames:
+  - context
+  - description
+  - method
+  - name
+  - title
+  - url
+  SourceURL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties
+required:
+- name
+- title
+- context
+- url
+- method
+- description
+title: Actions
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items
+==========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: recentTasks entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items
+TYPE_NAME: RecentTasksEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    runId: RunID
+    taskId: TaskID
+  Properties:
+    runId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/runId
+      TYPE_NAME: RunIdentifier
+      description: |
+        Id of this task run, `run-id`s always starts from `0`
+      maximum: 1000
+      minimum: 0
+      title: Run Identifier
+      type: integer
+    taskId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: taskId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/taskId
+      TYPE_NAME: TaskIdentifier
+      description: |
+        Unique task identifier, this is UUID encoded as
+        [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+        stripped of `=` padding.
+      pattern: ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+      title: Task Identifier
+      type: string
+  SortedPropertyNames:
+  - runId
+  - taskId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/queue/v1/workertype-response.json#
 =================================================================
 $schema: http://json-schema.org/draft-06/schema#
@@ -19223,7 +25661,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: actions
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions
-      TYPE_NAME: Actions
+      TYPE_NAME: WorkerTypeActions
       items:
         IS_REQUIRED: false
         PROPERTY_NAME: actions entry
@@ -19233,12 +25671,35 @@ properties:
           Boolean: false
           Properties: null
         description: |
-          Actions are defined on the provisioner and they are performed via a request using the `url` and `method`.
-          Depending on the `context`, the `url` will be filled with parameters. In addition, `context` is
-          used by the front-end to know where to display the action. For example, `context=worker`
-          will display the action on the worker explorer.
+          Actions provide a generic mechanism to expose additional features of a
+          provisioner, worker type, or worker to Taskcluster clients.
 
-          _Note: The request will be signed with the user's Taskcluster credentials._
+          An action is comprised of metadata describing the feature it exposes,
+          together with a webhook for triggering it.
+
+          The Taskcluster tools site, for example, retrieves actions when displaying
+          provisioners, worker types and workers. It presents the provisioner/worker
+          type/worker specific actions to the user. When the user triggers an action,
+          the web client takes the registered webhook, substitutes parameters into the
+          URL (see `url`), signs the requests with the Taskcluster credentials of the
+          user operating the web interface, and issues the HTTP request.
+
+          The level to which the action relates (provisioner, worker type, worker) is
+          called the action context. All actions, regardless of the action contexts,
+          are registered against the provisioner when calling
+          `queue.declareProvisioner`.
+
+          The action context is used by the web client to determine where in the web
+          interface to present the action to the user as follows:
+
+          | `context`   | Tool where action is displayed |
+          |-------------|--------------------------------|
+          | provisioner | Provisioner Explorer           |
+          | worker-type | Workers Explorer               |
+          | worker      | Worker Explorer                |
+
+          See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+          for more information.
         properties:
           MemberNames:
             context: Context
@@ -19254,14 +25715,7 @@ properties:
               SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/context
               TYPE_NAME: Context
               description: |
-                Actions have a "context" that is one of provisioner, worker-type,
-                or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-
-                | `context`   | Page displayed        |
-                |-------------|-----------------------|
-                | provisioner | Provisioner Explorer  |
-                | worker-type | Workers Explorer      |
-                | worker      | Worker Explorer       |
+                Only actions with the context `worker-type` are included.
               enum:
               - worker-type
               title: Context
@@ -19341,6 +25795,7 @@ properties:
         - description
         title: Actions
         type: object
+      title: Worker-type Actions
       type: array
     description:
       IS_REQUIRED: true
@@ -19410,7 +25865,7 @@ properties:
       maxLength: 22
       minLength: 1
       pattern: ^([a-zA-Z0-9-_]*)$
-      title: WorkerType name
+      title: Worker-type Name
       type: string
   SortedPropertyNames:
   - actions
@@ -19430,6 +25885,142 @@ required:
 - lastDateActive
 - actions
 title: Worker-type Response
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items
+==========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: actions entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items
+TYPE_NAME: Actions1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Actions provide a generic mechanism to expose additional features of a
+  provisioner, worker type, or worker to Taskcluster clients.
+
+  An action is comprised of metadata describing the feature it exposes,
+  together with a webhook for triggering it.
+
+  The Taskcluster tools site, for example, retrieves actions when displaying
+  provisioners, worker types and workers. It presents the provisioner/worker
+  type/worker specific actions to the user. When the user triggers an action,
+  the web client takes the registered webhook, substitutes parameters into the
+  URL (see `url`), signs the requests with the Taskcluster credentials of the
+  user operating the web interface, and issues the HTTP request.
+
+  The level to which the action relates (provisioner, worker type, worker) is
+  called the action context. All actions, regardless of the action contexts,
+  are registered against the provisioner when calling
+  `queue.declareProvisioner`.
+
+  The action context is used by the web client to determine where in the web
+  interface to present the action to the user as follows:
+
+  | `context`   | Tool where action is displayed |
+  |-------------|--------------------------------|
+  | provisioner | Provisioner Explorer           |
+  | worker-type | Workers Explorer               |
+  | worker      | Worker Explorer                |
+
+  See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+  for more information.
+properties:
+  MemberNames:
+    context: Context
+    description: Description
+    method: Method
+    name: Name
+    title: Title
+    url: URL
+  Properties:
+    context:
+      IS_REQUIRED: true
+      PROPERTY_NAME: context
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/context
+      TYPE_NAME: Context
+      description: |
+        Only actions with the context `worker-type` are included.
+      enum:
+      - worker-type
+      title: Context
+      type: string
+    description:
+      IS_REQUIRED: true
+      PROPERTY_NAME: description
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/description
+      TYPE_NAME: Description
+      description: |
+        Description of the provisioner.
+      title: Description
+      type: string
+    method:
+      IS_REQUIRED: true
+      PROPERTY_NAME: method
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/method
+      TYPE_NAME: Method
+      description: |
+        Method to indicate the desired action to be performed for a given resource.
+      enum:
+      - POST
+      - PUT
+      - DELETE
+      - PATCH
+      title: Method
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/name
+      TYPE_NAME: Name
+      description: |
+        Short names for things like logging/error messages.
+      title: Name
+      type: string
+    title:
+      IS_REQUIRED: true
+      PROPERTY_NAME: title
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/title
+      TYPE_NAME: Title
+      description: |
+        Appropriate title for any sort of Modal prompt.
+      title: Title
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/url
+      TYPE_NAME: URL
+      description: |
+        When an action is triggered, a request is made using the `url` and `method`.
+        Depending on the `context`, the following parameters will be substituted in the url:
+
+        | `context`   | Path parameters                                          |
+        |-------------|----------------------------------------------------------|
+        | provisioner | <provisionerId>                                          |
+        | worker-type | <provisionerId>, <workerType>                            |
+        | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+
+        _Note: The request needs to be signed with the user's Taskcluster credentials._
+      title: URL
+      type: string
+  SortedPropertyNames:
+  - context
+  - description
+  - method
+  - name
+  - title
+  - url
+  SourceURL: http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties
+required:
+- name
+- title
+- context
+- url
+- method
+- description
+title: Actions
 type: object
 
 
@@ -20061,7 +26652,7 @@ properties:
       IS_REQUIRED: true
       PROPERTY_NAME: artifact
       SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact
-      TYPE_NAME: ArtifactCreated
+      TYPE_NAME: ArtifactCreated1
       additionalProperties:
         Boolean: false
         Properties: null
@@ -20556,6 +27147,86 @@ required:
 - workerId
 - artifact
 title: Artifact Created Message
+type: object
+
+
+http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact
+==========================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: artifact
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact
+TYPE_NAME: ArtifactCreated1
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Information about the artifact that was created
+properties:
+  MemberNames:
+    contentType: ContentType
+    expires: Expires
+    name: Name
+    storageType: StorageType
+  Properties:
+    contentType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: contentType
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/contentType
+      TYPE_NAME: ContentType
+      description: |
+        Mimetype for the artifact that was created.
+      maxLength: 255
+      title: Content-Type
+      type: string
+    expires:
+      IS_REQUIRED: true
+      PROPERTY_NAME: expires
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/expires
+      TYPE_NAME: ArtifactExpiration
+      description: |
+        Date and time after which the artifact created will be automatically
+        deleted by the queue.
+      format: date-time
+      title: Artifact Expiration
+      type: string
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/name
+      TYPE_NAME: ArtifactName
+      description: |
+        Name of the artifact that was created, this is useful if you want to
+        attempt to fetch the artifact. But keep in mind that just because an
+        artifact is created doesn't mean that it's immediately available.
+      maxLength: 1024
+      title: Artifact Name
+      type: string
+    storageType:
+      IS_REQUIRED: true
+      PROPERTY_NAME: storageType
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/storageType
+      TYPE_NAME: ArtifactStorageType
+      description: |
+        This is the `storageType` for the request that was used to create the
+        artifact.
+      enum:
+      - blob
+      - reference
+      - error
+      title: Artifact Storage-Type
+      type: string
+  SortedPropertyNames:
+  - contentType
+  - expires
+  - name
+  - storageType
+  SourceURL: http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties
+required:
+- storageType
+- name
+- expires
+- contentType
+title: Artifact Created
 type: object
 
 
@@ -23581,6 +30252,194 @@ title: Task Status Structure
 type: object
 
 
+http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+===============================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: runs entry
+SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+TYPE_NAME: RunInformation
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  JSON object with information about a run
+properties:
+  MemberNames:
+    reasonCreated: ReasonCreated
+    reasonResolved: ReasonResolved
+    resolved: Resolved
+    runId: RunID
+    scheduled: Scheduled
+    started: Started
+    state: State
+    takenUntil: TakenUntil
+    workerGroup: WorkerGroup
+    workerId: WorkerID
+  Properties:
+    reasonCreated:
+      IS_REQUIRED: true
+      PROPERTY_NAME: reasonCreated
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+      TYPE_NAME: ReasonCreated
+      description: |
+        Reason for the creation of this run,
+        **more reasons may be added in the future**.
+      enum:
+      - scheduled
+      - retry
+      - task-retry
+      - rerun
+      - exception
+      title: Reason Created
+      type: string
+    reasonResolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: reasonResolved
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+      TYPE_NAME: ReasonResolved
+      description: |
+        Reason that run was resolved, this is mainly
+        useful for runs resolved as `exception`.
+        Note, **more reasons may be added in the future**, also this
+        property is only available after the run is resolved. Some of these
+        reasons, notably `intermittent-task`, `worker-shutdown`, and
+        `claim-expired`, will trigger an automatic retry of the task.
+      enum:
+      - completed
+      - failed
+      - deadline-exceeded
+      - canceled
+      - superseded
+      - claim-expired
+      - worker-shutdown
+      - malformed-payload
+      - resource-unavailable
+      - internal-error
+      - intermittent-task
+      title: Reason Resolved
+      type: string
+    resolved:
+      IS_REQUIRED: false
+      PROPERTY_NAME: resolved
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+      TYPE_NAME: Resolved
+      description: |
+        Date-time at which this run was resolved, ie. when the run changed
+        state from `running` to either `completed`, `failed` or `exception`.
+        This property is only present after the run as been resolved.
+      format: date-time
+      title: Resolved
+      type: string
+    runId:
+      IS_REQUIRED: true
+      PROPERTY_NAME: runId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+      TYPE_NAME: RunIdentifier
+      description: |
+        Id of this task run, `run-id`s always starts from `0`
+      maximum: 1000
+      minimum: 0
+      title: Run Identifier
+      type: integer
+    scheduled:
+      IS_REQUIRED: true
+      PROPERTY_NAME: scheduled
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+      TYPE_NAME: Scheduled
+      description: |
+        Date-time at which this run was scheduled, ie. when the run was
+        created in state `pending`.
+      format: date-time
+      title: Scheduled
+      type: string
+    started:
+      IS_REQUIRED: false
+      PROPERTY_NAME: started
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+      TYPE_NAME: Started
+      description: |
+        Date-time at which this run was claimed, ie. when the run changed
+        state from `pending` to `running`. This property is only present
+        after the run has been claimed.
+      format: date-time
+      title: Started
+      type: string
+    state:
+      IS_REQUIRED: true
+      PROPERTY_NAME: state
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+      TYPE_NAME: RunState
+      description: |
+        State of this run
+      enum:
+      - pending
+      - running
+      - completed
+      - failed
+      - exception
+      title: Run State
+      type: string
+    takenUntil:
+      IS_REQUIRED: false
+      PROPERTY_NAME: takenUntil
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+      TYPE_NAME: TakenUntil
+      description: |
+        Time at which the run expires and is resolved as `failed`, if the
+        run isn't reclaimed. Note, only present after the run has been
+        claimed.
+      format: date-time
+      title: Taken Until
+      type: string
+    workerGroup:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerGroup
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+      TYPE_NAME: WorkerGroup
+      description: |
+        Identifier for group that worker who executes this run is a part of,
+        this identifier is mainly used for efficient routing.
+        Note, this property is only present after the run is claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Group
+      type: string
+    workerId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerId
+      SOURCE_URL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+      TYPE_NAME: WorkerIdentifier
+      description: |
+        Identifier for worker evaluating this run within given
+        `workerGroup`. Note, this property is only available after the run
+        has been claimed.
+      maxLength: 22
+      minLength: 1
+      pattern: ^([a-zA-Z0-9-_]*)$
+      title: Worker Identifier
+      type: string
+  SortedPropertyNames:
+  - reasonCreated
+  - reasonResolved
+  - resolved
+  - runId
+  - scheduled
+  - started
+  - state
+  - takenUntil
+  - workerGroup
+  - workerId
+  SourceURL: http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties
+required:
+- runId
+- state
+- reasonCreated
+- scheduled
+title: Run Information
+type: object
+
+
 http://references.taskcluster.net/secrets/v1/api.json
 =====================================================
 Version     = '[48]'
@@ -24960,6 +31819,586 @@ required:
 type: object
 
 
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
+===========================================================================================
+IS_REQUIRED: true
+PROPERTY_NAME: display
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
+TYPE_NAME: Display
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    chunkCount: ChunkCount
+    chunkId: ChunkID
+    groupName: GroupName
+    groupSymbol: GroupSymbol
+    jobName: JobName
+    jobSymbol: JobSymbol
+  Properties:
+    chunkCount:
+      IS_REQUIRED: false
+      PROPERTY_NAME: chunkCount
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+      TYPE_NAME: ChunkCount
+      minimum: 1
+      title: chunkCount
+      type: integer
+    chunkId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: chunkId
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+      TYPE_NAME: ChunkID
+      minimum: 1
+      title: chunkId
+      type: integer
+    groupName:
+      IS_REQUIRED: false
+      PROPERTY_NAME: groupName
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+      TYPE_NAME: GroupName
+      maxLength: 100
+      minLength: 1
+      title: group name
+      type: string
+    groupSymbol:
+      IS_REQUIRED: true
+      PROPERTY_NAME: groupSymbol
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+      TYPE_NAME: GroupSymbol
+      maxLength: 25
+      minLength: 1
+      title: group symbol
+      type: string
+    jobName:
+      IS_REQUIRED: true
+      PROPERTY_NAME: jobName
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+      TYPE_NAME: JobName
+      maxLength: 100
+      minLength: 1
+      title: job name
+      type: string
+    jobSymbol:
+      IS_REQUIRED: true
+      PROPERTY_NAME: jobSymbol
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+      TYPE_NAME: JobSymbol
+      maxLength: 25
+      minLength: 0
+      title: jobSymbol
+      type: string
+  SortedPropertyNames:
+  - chunkCount
+  - chunkId
+  - groupName
+  - groupSymbol
+  - jobName
+  - jobSymbol
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties
+required:
+- jobName
+- jobSymbol
+- groupSymbol
+type: object
+
+
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
+===========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: jobInfo
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
+TYPE_NAME: JobInfo
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  Definition of the Job Info for a job.  These are extra data
+  fields that go along with a job that will be displayed in
+  the details panel within Treeherder.
+id: jobInfo
+properties:
+  MemberNames:
+    links: Links
+    summary: Summary
+  Properties:
+    links:
+      IS_REQUIRED: false
+      PROPERTY_NAME: links
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+      TYPE_NAME: Links
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: links entry
+        SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+        TYPE_NAME: LinksEntry
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        description: |
+          List of URLs shown as key/value pairs.  Shown as:
+          "<label>: <linkText>" where linkText will be a link to the url.
+        properties:
+          MemberNames:
+            label: Label
+            linkText: LinkText
+            url: URL
+          Properties:
+            label:
+              IS_REQUIRED: true
+              PROPERTY_NAME: label
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+              TYPE_NAME: Label
+              maxLength: 70
+              minLength: 1
+              type: string
+            linkText:
+              IS_REQUIRED: true
+              PROPERTY_NAME: linkText
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+              TYPE_NAME: LinkText
+              maxLength: 125
+              minLength: 1
+              type: string
+            url:
+              IS_REQUIRED: true
+              PROPERTY_NAME: url
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+              TYPE_NAME: URL
+              format: url
+              maxLength: 512
+              type: string
+          SortedPropertyNames:
+          - label
+          - linkText
+          - url
+          SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties
+        required:
+        - url
+        - linkText
+        - label
+        type: object
+      type: array
+    summary:
+      IS_REQUIRED: false
+      PROPERTY_NAME: summary
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+      TYPE_NAME: Summary
+      description: |
+        Plain text description of the job and its state.  Submitted with
+        the final message about a task.
+      type: string
+  SortedPropertyNames:
+  - links
+  - summary
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties
+type: object
+
+
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+==================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: links entry
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+TYPE_NAME: LinksEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+description: |
+  List of URLs shown as key/value pairs.  Shown as:
+  "<label>: <linkText>" where linkText will be a link to the url.
+properties:
+  MemberNames:
+    label: Label
+    linkText: LinkText
+    url: URL
+  Properties:
+    label:
+      IS_REQUIRED: true
+      PROPERTY_NAME: label
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+      TYPE_NAME: Label
+      maxLength: 70
+      minLength: 1
+      type: string
+    linkText:
+      IS_REQUIRED: true
+      PROPERTY_NAME: linkText
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+      TYPE_NAME: LinkText
+      maxLength: 125
+      minLength: 1
+      type: string
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+      TYPE_NAME: URL
+      format: url
+      maxLength: 512
+      type: string
+  SortedPropertyNames:
+  - label
+  - linkText
+  - url
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties
+required:
+- url
+- linkText
+- label
+type: object
+
+
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items
+==============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: logs entry
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items
+TYPE_NAME: LogsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    errorsTruncated: ErrorsTruncated
+    name: Name
+    steps: Steps
+    url: URL
+  Properties:
+    errorsTruncated:
+      IS_REQUIRED: false
+      PROPERTY_NAME: errorsTruncated
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+      TYPE_NAME: ErrorsTruncated
+      description: |
+        If true, indicates that the number of errors in the log was too
+        large and not all of those lines are indicated here.
+      type: boolean
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+      TYPE_NAME: Name
+      maxLength: 50
+      minLength: 1
+      type: string
+    steps:
+      IS_REQUIRED: false
+      PROPERTY_NAME: steps
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+      TYPE_NAME: Steps
+      description: |
+        This object defines what is seen in the Treeherder Log Viewer.
+        These values can be submitted here, or they will be generated
+        by Treeherder's internal log parsing process from the
+        submitted log.  If this value is submitted, Treeherder will
+        consider the log already parsed and skip parsing.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: steps entry
+        SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+        TYPE_NAME: StepsEntry
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            errors: Errors
+            lineFinished: LineFinished
+            lineStarted: LineStarted
+            name: Name
+            result: Result
+            timeFinished: TimeFinished
+            timeStarted: TimeStarted
+          Properties:
+            errors:
+              IS_REQUIRED: false
+              PROPERTY_NAME: errors
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+              TYPE_NAME: Errors
+              items:
+                IS_REQUIRED: false
+                PROPERTY_NAME: errors entry
+                SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+                TYPE_NAME: ErrorsEntry
+                additionalProperties:
+                  Boolean: false
+                  Properties: null
+                properties:
+                  MemberNames:
+                    line: Line
+                    linenumber: Linenumber
+                  Properties:
+                    line:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: line
+                      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+                      TYPE_NAME: Line
+                      maxLength: 255
+                      minLength: 1
+                      type: string
+                    linenumber:
+                      IS_REQUIRED: false
+                      PROPERTY_NAME: linenumber
+                      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+                      TYPE_NAME: Linenumber
+                      minimum: 0
+                      type: integer
+                  SortedPropertyNames:
+                  - line
+                  - linenumber
+                  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+                type: object
+              type: array
+            lineFinished:
+              IS_REQUIRED: true
+              PROPERTY_NAME: lineFinished
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+              TYPE_NAME: LineFinished
+              minimum: 0
+              type: integer
+            lineStarted:
+              IS_REQUIRED: true
+              PROPERTY_NAME: lineStarted
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+              TYPE_NAME: LineStarted
+              minimum: 0
+              type: integer
+            name:
+              IS_REQUIRED: true
+              PROPERTY_NAME: name
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+              TYPE_NAME: Name
+              maxLength: 255
+              minLength: 1
+              type: string
+            result:
+              IS_REQUIRED: true
+              PROPERTY_NAME: result
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+              TYPE_NAME: Result
+              enum:
+              - success
+              - fail
+              - exception
+              - canceled
+              - unknown
+              type: string
+            timeFinished:
+              IS_REQUIRED: true
+              PROPERTY_NAME: timeFinished
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+              TYPE_NAME: TimeFinished
+              format: date-time
+              type: string
+            timeStarted:
+              IS_REQUIRED: true
+              PROPERTY_NAME: timeStarted
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+              TYPE_NAME: TimeStarted
+              format: date-time
+              type: string
+          SortedPropertyNames:
+          - errors
+          - lineFinished
+          - lineStarted
+          - name
+          - result
+          - timeFinished
+          - timeStarted
+          SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties
+        required:
+        - name
+        - timeStarted
+        - lineStarted
+        - lineFinished
+        - timeFinished
+        - result
+        type: object
+      type: array
+    url:
+      IS_REQUIRED: true
+      PROPERTY_NAME: url
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+      TYPE_NAME: URL
+      format: uri
+      maxLength: 255
+      minLength: 1
+      type: string
+  SortedPropertyNames:
+  - errorsTruncated
+  - name
+  - steps
+  - url
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties
+required:
+- url
+- name
+type: object
+
+
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+=====================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: steps entry
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+TYPE_NAME: StepsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    errors: Errors
+    lineFinished: LineFinished
+    lineStarted: LineStarted
+    name: Name
+    result: Result
+    timeFinished: TimeFinished
+    timeStarted: TimeStarted
+  Properties:
+    errors:
+      IS_REQUIRED: false
+      PROPERTY_NAME: errors
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+      TYPE_NAME: Errors
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: errors entry
+        SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+        TYPE_NAME: ErrorsEntry
+        additionalProperties:
+          Boolean: false
+          Properties: null
+        properties:
+          MemberNames:
+            line: Line
+            linenumber: Linenumber
+          Properties:
+            line:
+              IS_REQUIRED: false
+              PROPERTY_NAME: line
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+              TYPE_NAME: Line
+              maxLength: 255
+              minLength: 1
+              type: string
+            linenumber:
+              IS_REQUIRED: false
+              PROPERTY_NAME: linenumber
+              SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+              TYPE_NAME: Linenumber
+              minimum: 0
+              type: integer
+          SortedPropertyNames:
+          - line
+          - linenumber
+          SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+        type: object
+      type: array
+    lineFinished:
+      IS_REQUIRED: true
+      PROPERTY_NAME: lineFinished
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+      TYPE_NAME: LineFinished
+      minimum: 0
+      type: integer
+    lineStarted:
+      IS_REQUIRED: true
+      PROPERTY_NAME: lineStarted
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+      TYPE_NAME: LineStarted
+      minimum: 0
+      type: integer
+    name:
+      IS_REQUIRED: true
+      PROPERTY_NAME: name
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+      TYPE_NAME: Name
+      maxLength: 255
+      minLength: 1
+      type: string
+    result:
+      IS_REQUIRED: true
+      PROPERTY_NAME: result
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+      TYPE_NAME: Result
+      enum:
+      - success
+      - fail
+      - exception
+      - canceled
+      - unknown
+      type: string
+    timeFinished:
+      IS_REQUIRED: true
+      PROPERTY_NAME: timeFinished
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+      TYPE_NAME: TimeFinished
+      format: date-time
+      type: string
+    timeStarted:
+      IS_REQUIRED: true
+      PROPERTY_NAME: timeStarted
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+      TYPE_NAME: TimeStarted
+      format: date-time
+      type: string
+  SortedPropertyNames:
+  - errors
+  - lineFinished
+  - lineStarted
+  - name
+  - result
+  - timeFinished
+  - timeStarted
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties
+required:
+- name
+- timeStarted
+- lineStarted
+- lineFinished
+- timeFinished
+- result
+type: object
+
+
+http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+=============================================================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: errors entry
+SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+TYPE_NAME: ErrorsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    line: Line
+    linenumber: Linenumber
+  Properties:
+    line:
+      IS_REQUIRED: false
+      PROPERTY_NAME: line
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+      TYPE_NAME: Line
+      maxLength: 255
+      minLength: 1
+      type: string
+    linenumber:
+      IS_REQUIRED: false
+      PROPERTY_NAME: linenumber
+      SOURCE_URL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+      TYPE_NAME: Linenumber
+      minimum: 0
+      type: integer
+  SortedPropertyNames:
+  - line
+  - linenumber
+  SourceURL: http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[0]
 ===================================================================================================
 IS_REQUIRED: false
@@ -25634,6 +33073,91 @@ title: Errors
 type: object
 
 
+http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items
+==================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: errors entry
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items
+TYPE_NAME: ErrorsEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    az: Az
+    code: Code
+    instanceType: InstanceType
+    message: Message
+    region: Region
+    time: Time
+    type: Type
+    workerType: WorkerType
+  Properties:
+    az:
+      IS_REQUIRED: false
+      PROPERTY_NAME: az
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/az
+      TYPE_NAME: Az
+      type: string
+    code:
+      IS_REQUIRED: false
+      PROPERTY_NAME: code
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/code
+      TYPE_NAME: Code
+      type: string
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      type: string
+    message:
+      IS_REQUIRED: false
+      PROPERTY_NAME: message
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/message
+      TYPE_NAME: Message
+      type: string
+    region:
+      IS_REQUIRED: false
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/region
+      TYPE_NAME: Region
+      type: string
+    time:
+      IS_REQUIRED: false
+      PROPERTY_NAME: time
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/time
+      TYPE_NAME: Time
+      format: date-time
+      type: string
+    type:
+      IS_REQUIRED: false
+      PROPERTY_NAME: type
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/type
+      TYPE_NAME: Type
+      enum:
+      - instance-request
+      - termination
+      type: string
+    workerType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: workerType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/workerType
+      TYPE_NAME: WorkerType
+      type: string
+  SortedPropertyNames:
+  - az
+  - code
+  - instanceType
+  - message
+  - region
+  - time
+  - type
+  - workerType
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/ec2-manager/v1/health.json#
 ==========================================================
 $schema: http://json-schema.org/draft-04/schema#
@@ -25976,6 +33500,305 @@ title: Health of the EC2 account
 type: object
 
 
+http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items
+=========================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: requestHealth entry
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items
+TYPE_NAME: RequestHealthEntry
+description: |
+  This is a list of outcomes for a specific region, availability zone and
+  instance type.  These are calls to the EC2 runInstances method, which
+  is how we request instances.  If a call to this method is successful,
+  then we expect to get an instance to match
+properties:
+  MemberNames:
+    az: Az
+    configuration_issue: Configuration_Issue
+    failed: Failed
+    instanceType: InstanceType
+    insufficient_capacity: Insufficient_Capacity
+    limit_exceeded: Limit_Exceeded
+    region: Region
+    successful: Successful
+    throttled_calls: Throttled_Calls
+  Properties:
+    az:
+      IS_REQUIRED: false
+      PROPERTY_NAME: az
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/az
+      TYPE_NAME: Az
+      type: string
+    configuration_issue:
+      IS_REQUIRED: false
+      PROPERTY_NAME: configuration_issue
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/configuration_issue
+      TYPE_NAME: Configuration_Issue
+      description: The number of calls failed due to a misconfiguration of the worker
+        type.  Due to the large number of error codes the EC2 API might return, this
+        is a best effort categorization.  It covers codes which are like "Invalid%"
+        using SQL pattern mattching on the codes from https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+        It is not categorized by which field was invalid in this response
+      type: integer
+    failed:
+      IS_REQUIRED: false
+      PROPERTY_NAME: failed
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/failed
+      TYPE_NAME: Failed
+      description: The total number of calls which failed, inrespective of why
+      type: integer
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      type: string
+    insufficient_capacity:
+      IS_REQUIRED: false
+      PROPERTY_NAME: insufficient_capacity
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/insufficient_capacity
+      TYPE_NAME: Insufficient_Capacity
+      description: |
+        Number of runInstances calls which have failed because there aren't
+        enough hosts for the resources to be allocated.
+      type: integer
+    limit_exceeded:
+      IS_REQUIRED: false
+      PROPERTY_NAME: limit_exceeded
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/limit_exceeded
+      TYPE_NAME: Limit_Exceeded
+      description: |
+        The number of calls which failed due to a limit being exceeded.
+        Due to the large number of error codes the EC2 API might return,
+        this is a best effort categorization.  It covers codes which are
+        like "%LimitExceeded" using SQL pattern mattching, but not
+        RequestLimitExceeded on the codes from
+        https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+        It is not categorized by which limit was exceeded in this response
+      type: integer
+    region:
+      IS_REQUIRED: false
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/region
+      TYPE_NAME: Region
+      type: string
+    successful:
+      IS_REQUIRED: false
+      PROPERTY_NAME: successful
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/successful
+      TYPE_NAME: Successful
+      description: |
+        The number of instances which have been requested successfully
+      type: integer
+    throttled_calls:
+      IS_REQUIRED: false
+      PROPERTY_NAME: throttled_calls
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/throttled_calls
+      TYPE_NAME: Throttled_Calls
+      description: |
+        Number of calls which have been throttled in this region.  These
+        are errors with the code RequestLimitExceeded.
+      type: integer
+  SortedPropertyNames:
+  - az
+  - configuration_issue
+  - failed
+  - instanceType
+  - insufficient_capacity
+  - limit_exceeded
+  - region
+  - successful
+  - throttled_calls
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties
+type: object
+
+
+http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items
+===================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: running entry
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items
+TYPE_NAME: RunningEntry
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    az: Az
+    instanceType: InstanceType
+    region: Region
+    running: Running
+  Properties:
+    az:
+      IS_REQUIRED: false
+      PROPERTY_NAME: az
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/az
+      TYPE_NAME: Az
+      type: string
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      type: string
+    region:
+      IS_REQUIRED: false
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/region
+      TYPE_NAME: Region
+      type: string
+    running:
+      IS_REQUIRED: false
+      PROPERTY_NAME: running
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/running
+      TYPE_NAME: Running
+      description: |
+        The number of currently running instances in this configuration
+      type: integer
+  SortedPropertyNames:
+  - az
+  - instanceType
+  - region
+  - running
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties
+type: object
+
+
+http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items
+=============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: terminationHealth entry
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items
+TYPE_NAME: TerminationHealthEntry
+description: |
+  This is a list of summaries of instances which have terminated
+properties:
+  MemberNames:
+    az: Az
+    clean_shutdown: Clean_Shutdown
+    instanceType: InstanceType
+    insufficient_capacity: Insufficient_Capacity
+    missing_ami: Missing_Ami
+    no_code: No_Code
+    region: Region
+    spot_kill: Spot_Kill
+    startup_failed: Startup_Failed
+    unknown_code: Unknown_Code
+    volume_limit_exceeded: Volume_Limit_Exceeded
+  Properties:
+    az:
+      IS_REQUIRED: false
+      PROPERTY_NAME: az
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/az
+      TYPE_NAME: Az
+      type: string
+    clean_shutdown:
+      IS_REQUIRED: false
+      PROPERTY_NAME: clean_shutdown
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/clean_shutdown
+      TYPE_NAME: Clean_Shutdown
+      description: |
+        A count of the instances which were shutdown cleanty.  For the
+        purposes of this API, a clean shutdown is one which was initiated
+        by us.  This includes API shutdowns or workers ending themselves.
+        It does not mean the actual workload ran successfully, rather that
+        we chose to terminate it
+      type: integer
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      type: string
+    insufficient_capacity:
+      IS_REQUIRED: false
+      PROPERTY_NAME: insufficient_capacity
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/insufficient_capacity
+      TYPE_NAME: Insufficient_Capacity
+      description: |
+        The number of instances which were terminated due to a lack of
+        capacity.  More than likely, this will always be zero because the
+        new spot service is now synchronous, so runInstances calls should
+        fail
+      type: integer
+    missing_ami:
+      IS_REQUIRED: false
+      PROPERTY_NAME: missing_ami
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/missing_ami
+      TYPE_NAME: Missing_Ami
+      description: |
+        The number of instances which were terminated due to not being able
+        to find the AMI
+      type: integer
+    no_code:
+      IS_REQUIRED: false
+      PROPERTY_NAME: no_code
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/no_code
+      TYPE_NAME: No_Code
+      description: |
+        The number of terminations which we cannot find a code.  This means
+        we cannot determine whether this should be classified as a good or
+        bad outcome.  The specific reason is that the code which polls for
+        termination reason was not able to run before the EC2 API dropped
+        the instance from its database
+      type: integer
+    region:
+      IS_REQUIRED: false
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/region
+      TYPE_NAME: Region
+      type: string
+    spot_kill:
+      IS_REQUIRED: false
+      PROPERTY_NAME: spot_kill
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/spot_kill
+      TYPE_NAME: Spot_Kill
+      description: |
+        The number of instances which were killed by the spot service
+      type: integer
+    startup_failed:
+      IS_REQUIRED: false
+      PROPERTY_NAME: startup_failed
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/startup_failed
+      TYPE_NAME: Startup_Failed
+      description: |
+        The number of instances which failed to start, either because of an
+        error on our side or on the EC2 side
+      type: integer
+    unknown_code:
+      IS_REQUIRED: false
+      PROPERTY_NAME: unknown_code
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/unknown_code
+      TYPE_NAME: Unknown_Code
+      description: |
+        The number of terminations which have a code which this code does
+        not recognize
+      type: integer
+    volume_limit_exceeded:
+      IS_REQUIRED: false
+      PROPERTY_NAME: volume_limit_exceeded
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/volume_limit_exceeded
+      TYPE_NAME: Volume_Limit_Exceeded
+      description: |
+        The number of instances which were terminated due to exceeding the
+        limit for number of ebs volumes
+      type: integer
+  SortedPropertyNames:
+  - az
+  - clean_shutdown
+  - instanceType
+  - insufficient_capacity
+  - missing_ami
+  - no_code
+  - region
+  - spot_kill
+  - startup_failed
+  - unknown_code
+  - volume_limit_exceeded
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/ec2-manager/v1/list-worker-types.json#
 =====================================================================
 $schema: http://json-schema.org/draft-04/schema#
@@ -26044,17 +33867,17 @@ items:
           - IS_REQUIRED: false
             PROPERTY_NAME: ""
             SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[0]
-            TYPE_NAME: Var
+            TYPE_NAME: Var1
             type: number
           - IS_REQUIRED: false
             PROPERTY_NAME: ""
             SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[1]
-            TYPE_NAME: Var1
+            TYPE_NAME: Var2
             type: string
           - IS_REQUIRED: false
             PROPERTY_NAME: ""
             SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[2]
-            TYPE_NAME: Var2
+            TYPE_NAME: Var3
             items:
               IS_REQUIRED: false
               PROPERTY_NAME: ' entry'
@@ -26072,12 +33895,76 @@ title: List of restrictions for prices
 type: array
 
 
+http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items
+========================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ' entry'
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items
+TYPE_NAME: Entry3
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    key: Key
+    restriction: Restriction
+  Properties:
+    key:
+      IS_REQUIRED: false
+      PROPERTY_NAME: key
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/key
+      TYPE_NAME: Key
+      enum:
+      - instanceType
+      - region
+      - price
+      - minPrice
+      - maxPrice
+      - zone
+      - type
+      type: string
+    restriction:
+      IS_REQUIRED: false
+      PROPERTY_NAME: restriction
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction
+      TYPE_NAME: Restriction
+      oneOf:
+        Items:
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[0]
+          TYPE_NAME: Var1
+          type: number
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[1]
+          TYPE_NAME: Var2
+          type: string
+        - IS_REQUIRED: false
+          PROPERTY_NAME: ""
+          SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[2]
+          TYPE_NAME: Var3
+          items:
+            IS_REQUIRED: false
+            PROPERTY_NAME: ' entry'
+            SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[2]/items
+            TYPE_NAME: Entry2
+            type: string
+          type: array
+        SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf
+  SortedPropertyNames:
+  - key
+  - restriction
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties
+type: object
+
+
 http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[0]
 ========================================================================================================
 IS_REQUIRED: false
 PROPERTY_NAME: ""
 SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[0]
-TYPE_NAME: Var
+TYPE_NAME: Var1
 type: number
 
 
@@ -26086,7 +33973,7 @@ http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/propert
 IS_REQUIRED: false
 PROPERTY_NAME: ""
 SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[1]
-TYPE_NAME: Var1
+TYPE_NAME: Var2
 type: string
 
 
@@ -26095,7 +33982,7 @@ http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/propert
 IS_REQUIRED: false
 PROPERTY_NAME: ""
 SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[2]
-TYPE_NAME: Var2
+TYPE_NAME: Var3
 items:
   IS_REQUIRED: false
   PROPERTY_NAME: ' entry'
@@ -26178,6 +34065,70 @@ items:
   type: object
 title: List of prices
 type: array
+
+
+http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items
+================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: ' entry'
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items
+TYPE_NAME: Entry1
+additionalProperties:
+  Boolean: false
+  Properties: null
+properties:
+  MemberNames:
+    instanceType: InstanceType
+    price: Price
+    region: Region
+    type: Type
+    zone: Zone
+  Properties:
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      description: EC2 instance type
+      type: string
+    price:
+      IS_REQUIRED: false
+      PROPERTY_NAME: price
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties/price
+      TYPE_NAME: Price
+      description: Amount of dollars for an hour of usage for this configuration
+      type: number
+    region:
+      IS_REQUIRED: false
+      PROPERTY_NAME: region
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties/region
+      TYPE_NAME: Region
+      description: EC2 region
+      type: string
+    type:
+      IS_REQUIRED: false
+      PROPERTY_NAME: type
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties/type
+      TYPE_NAME: Type
+      enum:
+      - spot
+      - ondemand
+      type: string
+    zone:
+      IS_REQUIRED: false
+      PROPERTY_NAME: zone
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties/zone
+      TYPE_NAME: Zone
+      description: EC2 availability zone identifier
+      type: string
+  SortedPropertyNames:
+  - instanceType
+  - price
+  - region
+  - type
+  - zone
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items/properties
+type: object
 
 
 http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#
@@ -26329,6 +34280,76 @@ title: Make a spot request
 type: object
 
 
+http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo
+==============================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: LaunchInfo
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo
+TYPE_NAME: LaunchInfo
+description: |
+  This is an EC2-Manager specific wrapping of the request body for the
+  upstream EC2 API.  Values from this are passed through verbatim.  A small
+  number of checks are done on the data before making the call, as well as
+  having some schema keys set to ensure certain values are either present
+  or absent
+properties:
+  MemberNames:
+    ImageId: ImageID
+    InstanceType: InstanceType
+    KeyName: KeyName
+    SecurityGroups: SecurityGroups
+  Properties:
+    ImageId:
+      IS_REQUIRED: false
+      PROPERTY_NAME: ImageId
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/ImageId
+      TYPE_NAME: ImageID
+      description: |
+        This is the AMI Identifier for this spot request.  This image must
+        already exist and must be in the region of the request.  Note that
+        AMI images are per-region, so you must copy or regenerate the image
+        for each region.
+      type: string
+    InstanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: InstanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/InstanceType
+      TYPE_NAME: InstanceType
+      description: |
+        The instance type to use for this spot request
+      type: string
+    KeyName:
+      IS_REQUIRED: false
+      PROPERTY_NAME: KeyName
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/KeyName
+      TYPE_NAME: KeyName
+      description: |
+        A valid EC2 KeyPair name.  The KeyPair must already exist
+      type: string
+    SecurityGroups:
+      IS_REQUIRED: false
+      PROPERTY_NAME: SecurityGroups
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/SecurityGroups
+      TYPE_NAME: SecurityGroups
+      description: |
+        This is a list of the security groups this image will use.  These
+        groups must already exist in the region.
+      items:
+        IS_REQUIRED: false
+        PROPERTY_NAME: SecurityGroups entry
+        SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/SecurityGroups/items
+        TYPE_NAME: SecurityGroupsEntry
+        type: string
+      type: array
+  SortedPropertyNames:
+  - ImageId
+  - InstanceType
+  - KeyName
+  - SecurityGroups
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties
+type: object
+
+
 http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#
 =========================================================================
 $schema: http://json-schema.org/draft-04/schema#
@@ -26401,6 +34422,46 @@ properties:
   - running
   SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties
 title: Overview of computational resources
+type: object
+
+
+http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items
+==================================================================================================
+IS_REQUIRED: false
+PROPERTY_NAME: pending entry
+SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items
+TYPE_NAME: PendingEntry
+properties:
+  MemberNames:
+    count: Count
+    instanceType: InstanceType
+    type: Type
+  Properties:
+    count:
+      IS_REQUIRED: false
+      PROPERTY_NAME: count
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/count
+      TYPE_NAME: Count
+      type: number
+    instanceType:
+      IS_REQUIRED: false
+      PROPERTY_NAME: instanceType
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/instanceType
+      TYPE_NAME: InstanceType
+      type: string
+    type:
+      IS_REQUIRED: false
+      PROPERTY_NAME: type
+      SOURCE_URL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/type
+      TYPE_NAME: Type
+      enum:
+      - instance
+      type: string
+  SortedPropertyNames:
+  - count
+  - instanceType
+  - type
+  SourceURL: http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties
 type: object
 
 

--- a/codegenerator/model/model.go
+++ b/codegenerator/model/model.go
@@ -231,10 +231,11 @@ func GenerateCode(goOutputDir, modelData string, downloaded time.Time) {
 
 		fmt.Printf("Generating go types for %s\n", apiDefs[i].PackageName)
 		job := &jsonschema2go.Job{
-			Package:           apiDefs[i].PackageName,
-			URLs:              apiDefs[i].schemaURLs,
-			ExportTypes:       true,
-			TypeNameBlacklist: apiDefs[i].members,
+			Package:              apiDefs[i].PackageName,
+			URLs:                 apiDefs[i].schemaURLs,
+			ExportTypes:          true,
+			TypeNameBlacklist:    apiDefs[i].members,
+			DisableNestedStructs: true,
 		}
 		result, err := job.Execute()
 		exitOnFail(err)

--- a/tcauth/tcauth.go
+++ b/tcauth/tcauth.go
@@ -70,7 +70,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/auth/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcauth
 

--- a/tcauth/types.go
+++ b/tcauth/types.go
@@ -18,25 +18,7 @@ type (
 		// Temporary STS credentials for use when operating on S3
 		//
 		// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials
-		Credentials struct {
-
-			// Access key identifier that identifies the temporary security
-			// credentials.
-			//
-			// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/accessKeyId
-			AccessKeyID string `json:"accessKeyId"`
-
-			// Secret access key used to sign requests
-			//
-			// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/secretAccessKey
-			SecretAccessKey string `json:"secretAccessKey"`
-
-			// A token that must passed with request to use the temporary
-			// security credentials.
-			//
-			// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/sessionToken
-			SessionToken string `json:"sessionToken"`
-		} `json:"credentials"`
+		Credentials TemporarySecurityCredentials `json:"credentials"`
 
 		// Date and time of when the temporary credentials expires.
 		//
@@ -313,6 +295,29 @@ type (
 		Scopes []string `json:"scopes"`
 	}
 
+	// Access credentials and urls for the Sentry project.
+	// Credentials will expire in 24-48 hours, you should refresh them within
+	// 24 hours.
+	//
+	// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn
+	Dsn struct {
+
+		// Access credential and URL for public error reports.
+		// These credentials can be used for up-to 24 hours.
+		// This is for use in client-side applications only.
+		//
+		// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/public
+		Public string `json:"public"`
+
+		// Access credential and URL for private error reports.
+		// These credentials can be used for up-to 24 hours.
+		// This is for use in serser-side applications and should **not** be
+		// leaked.
+		//
+		// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/secret
+		Secret string `json:"secret"`
+	}
+
 	// Get all details about a client, useful for tools modifying a client
 	//
 	// See http://schemas.taskcluster.net/auth/v1/get-client-response.json#
@@ -533,23 +538,7 @@ type (
 		// 24 hours.
 		//
 		// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn
-		Dsn struct {
-
-			// Access credential and URL for public error reports.
-			// These credentials can be used for up-to 24 hours.
-			// This is for use in client-side applications only.
-			//
-			// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/public
-			Public string `json:"public"`
-
-			// Access credential and URL for private error reports.
-			// These credentials can be used for up-to 24 hours.
-			// This is for use in serser-side applications and should **not** be
-			// leaked.
-			//
-			// See http://schemas.taskcluster.net/auth/v1/sentry-dsn-response.json#/properties/dsn/properties/secret
-			Secret string `json:"secret"`
-		} `json:"dsn"`
+		Dsn Dsn `json:"dsn"`
 
 		// Expiration time for the credentials. The credentials should not be used
 		// after this time. They might not be revoked immediately, but will be at
@@ -599,6 +588,29 @@ type (
 		//
 		// See http://schemas.taskcluster.net/auth/v1/statsum-token-response.json#/properties/token
 		Token string `json:"token"`
+	}
+
+	// Temporary STS credentials for use when operating on S3
+	//
+	// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials
+	TemporarySecurityCredentials struct {
+
+		// Access key identifier that identifies the temporary security
+		// credentials.
+		//
+		// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/accessKeyId
+		AccessKeyID string `json:"accessKeyId"`
+
+		// Secret access key used to sign requests
+		//
+		// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/secretAccessKey
+		SecretAccessKey string `json:"secretAccessKey"`
+
+		// A token that must passed with request to use the temporary
+		// security credentials.
+		//
+		// See http://schemas.taskcluster.net/auth/v1/aws-s3-credentials-response.json#/properties/credentials/properties/sessionToken
+		SessionToken string `json:"sessionToken"`
 	}
 
 	// Details on how the test request should be authenticated.

--- a/tcawsprovisioner/tcawsprovisioner.go
+++ b/tcawsprovisioner/tcawsprovisioner.go
@@ -58,7 +58,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/aws-provisioner/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcawsprovisioner
 

--- a/tcawsprovisioner/types.go
+++ b/tcawsprovisioner/types.go
@@ -10,6 +10,88 @@ import (
 )
 
 type (
+	// Availability zone configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items
+	AvailabilityZonesEntry struct {
+
+		// The AWS availability zone being configured.  Example: eu-central-1b
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/availabilityZone
+		AvailabilityZone string `json:"availabilityZone"`
+
+		// LaunchSpecification entries unique to this AZ
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/launchSpec
+		LaunchSpec json.RawMessage `json:"launchSpec"`
+
+		// The AWS region containing this availability zone.  Example: eu-central-1
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/region
+		Region string `json:"region"`
+
+		// Static Secrets unique to this AZ
+		//
+		// Default:    {}
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets,omitempty"`
+
+		// UserData entries unique to this AZ
+		//
+		// Default:    {}
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/userData
+		UserData json.RawMessage `json:"userData,omitempty"`
+	}
+
+	// Availability zone configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items
+	AvailabilityZonesEntry1 struct {
+
+		// The AWS availability zone being configured.  Example: eu-central-1b
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/availabilityZone
+		AvailabilityZone string `json:"availabilityZone"`
+
+		// LaunchSpecification entries unique to this AZ
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/launchSpec
+		LaunchSpec json.RawMessage `json:"launchSpec"`
+
+		// The AWS region containing this availability zone.  Example: eu-central-1
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/region
+		Region string `json:"region"`
+
+		// Static Secrets unique to this AZ
+		//
+		// Default:    {}
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets,omitempty"`
+
+		// UserData entries unique to this AZ
+		//
+		// Default:    {}
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/userData
+		UserData json.RawMessage `json:"userData,omitempty"`
+	}
+
 	// Backend Status Response
 	//
 	// See http://schemas.taskcluster.net/aws-provisioner/v1/backend-status-response.json#
@@ -36,43 +118,7 @@ type (
 	CreateWorkerTypeRequest struct {
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones
-		AvailabilityZones []struct {
-
-			// The AWS availability zone being configured.  Example: eu-central-1b
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/availabilityZone
-			AvailabilityZone string `json:"availabilityZone"`
-
-			// LaunchSpecification entries unique to this AZ
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// The AWS region containing this availability zone.  Example: eu-central-1
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/region
-			Region string `json:"region"`
-
-			// Static Secrets unique to this AZ
-			//
-			// Default:    {}
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets,omitempty"`
-
-			// UserData entries unique to this AZ
-			//
-			// Default:    {}
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/availabilityZones/items/properties/userData
-			UserData json.RawMessage `json:"userData,omitempty"`
-		} `json:"availabilityZones,omitempty"`
+		AvailabilityZones []AvailabilityZonesEntry `json:"availabilityZones,omitempty"`
 
 		// True if this worker type is allowed on demand instances.  Currently
 		// ignored
@@ -92,55 +138,7 @@ type (
 		Description string `json:"description"`
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes
-		InstanceTypes []struct {
-
-			// This number represents the number of tasks that this instance type
-			// is capable of running concurrently.  This is used by the provisioner
-			// to know how many pending tasks to offset a pending instance of this
-			// type by
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/capacity
-			Capacity float64 `json:"capacity"`
-
-			// InstanceType name for Amazon.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/instanceType
-			InstanceType string `json:"instanceType"`
-
-			// LaunchSpecification entries unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// Scopes which should be included for this InstanceType.  Scopes must
-			// be composed of printable ASCII characters and spaces.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/scopes
-			Scopes []string `json:"scopes"`
-
-			// Static Secrets unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets"`
-
-			// UserData entries unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/userData
-			UserData json.RawMessage `json:"userData"`
-
-			// This number is a relative measure of performance between two instance
-			// types.  It is multiplied by the spot price from Amazon to figure out
-			// which instance type is the cheapest one
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/utility
-			Utility float64 `json:"utility"`
-		} `json:"instanceTypes"`
+		InstanceTypes []InstanceTypesEntry `json:"instanceTypes"`
 
 		// Launch Specification entries which are used in all regions and all instance types
 		//
@@ -183,57 +181,7 @@ type (
 		Owner string `json:"owner"`
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions
-		Regions []struct {
-
-			// LaunchSpecification entries unique to this Region
-			//
-			// Defined properties:
-			//
-			//  struct {
-			//
-			//  	// Per-region AMI ImageId
-			//  	//
-			//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties/ImageId
-			//  	ImageID string `json:"ImageId"`
-			//  }
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// The Amazon AWS Region being configured.  Example: us-west-1
-			//
-			// Possible values:
-			//   * "us-west-2"
-			//   * "us-east-1"
-			//   * "us-east-2"
-			//   * "us-west-1"
-			//   * "eu-central-1"
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/region
-			Region string `json:"region"`
-
-			// Scopes which should be included for this Region.  Scopes must be
-			// composed of printable ASCII characters and spaces.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/scopes
-			Scopes []string `json:"scopes"`
-
-			// Static Secrets unique to this Region
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets"`
-
-			// UserData entries unique to this Region
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/userData
-			UserData json.RawMessage `json:"userData"`
-		} `json:"regions"`
+		Regions []RegionsEntry `json:"regions"`
 
 		// A scaling ratio of `0.2` means that the provisioner will attempt to keep
 		// the number of pending tasks around 20% of the provisioned capacity.
@@ -268,6 +216,21 @@ type (
 		//
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/userData
 		UserData json.RawMessage `json:"userData"`
+	}
+
+	// Generated Temporary credentials from the Provisioner
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials
+	Credentials struct {
+
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/accessToken
+		AccessToken string `json:"accessToken"`
+
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/certificate
+		Certificate string `json:"certificate"`
+
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/clientId
+		ClientID string `json:"clientId"`
 	}
 
 	// All of the launch specifications for a worker type
@@ -321,17 +284,7 @@ type (
 		// Generated Temporary credentials from the Provisioner
 		//
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials
-		Credentials struct {
-
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/accessToken
-			AccessToken string `json:"accessToken"`
-
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/certificate
-			Certificate string `json:"certificate"`
-
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-secret-response.json#/properties/credentials/properties/clientId
-			ClientID string `json:"clientId"`
-		} `json:"credentials"`
+		Credentials Credentials `json:"credentials"`
 
 		// Free-form object which contains secrets from the worker type definition
 		//
@@ -350,43 +303,7 @@ type (
 	GetWorkerTypeResponse struct {
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones
-		AvailabilityZones []struct {
-
-			// The AWS availability zone being configured.  Example: eu-central-1b
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/availabilityZone
-			AvailabilityZone string `json:"availabilityZone"`
-
-			// LaunchSpecification entries unique to this AZ
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// The AWS region containing this availability zone.  Example: eu-central-1
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/region
-			Region string `json:"region"`
-
-			// Static Secrets unique to this AZ
-			//
-			// Default:    {}
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets,omitempty"`
-
-			// UserData entries unique to this AZ
-			//
-			// Default:    {}
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/availabilityZones/items/properties/userData
-			UserData json.RawMessage `json:"userData,omitempty"`
-		} `json:"availabilityZones,omitempty"`
+		AvailabilityZones []AvailabilityZonesEntry1 `json:"availabilityZones,omitempty"`
 
 		// True if this worker type is allowed on demand instances.  Currently
 		// ignored
@@ -406,55 +323,7 @@ type (
 		Description string `json:"description"`
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes
-		InstanceTypes []struct {
-
-			// This number represents the number of tasks that this instance type
-			// is capable of running concurrently.  This is used by the provisioner
-			// to know how many pending tasks to offset a pending instance of this
-			// type by
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/capacity
-			Capacity float64 `json:"capacity"`
-
-			// InstanceType name for Amazon.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/instanceType
-			InstanceType string `json:"instanceType"`
-
-			// LaunchSpecification entries unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// Scopes which should be included for this InstanceType.  Scopes must
-			// be composed of printable ASCII characters and spaces.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/scopes
-			Scopes []string `json:"scopes"`
-
-			// Static Secrets unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets"`
-
-			// UserData entries unique to this InstanceType
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/userData
-			UserData json.RawMessage `json:"userData"`
-
-			// This number is a relative measure of performance between two instance
-			// types.  It is multiplied by the spot price from Amazon to figure out
-			// which instance type is the cheapest one
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/utility
-			Utility float64 `json:"utility"`
-		} `json:"instanceTypes"`
+		InstanceTypes []InstanceTypesEntry1 `json:"instanceTypes"`
 
 		// ISO Date string (e.g. new Date().toISOString()) which represents the time
 		// when this worker type definition was last altered (inclusive of creation)
@@ -503,50 +372,7 @@ type (
 		Owner string `json:"owner"`
 
 		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions
-		Regions []struct {
-
-			// LaunchSpecification entries unique to this Region
-			//
-			// Defined properties:
-			//
-			//  struct {
-			//
-			//  	// Per-region AMI ImageId
-			//  	//
-			//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties/ImageId
-			//  	ImageID string `json:"ImageId"`
-			//  }
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
-			LaunchSpec json.RawMessage `json:"launchSpec"`
-
-			// The Amazon AWS Region being configured.  Example: us-west-1
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/region
-			Region string `json:"region"`
-
-			// Scopes which should be included for this Region.  Scopes must be
-			// composed of printable ASCII characters and spaces.
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/scopes
-			Scopes []string `json:"scopes"`
-
-			// Static Secrets unique to this Region
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/secrets
-			Secrets json.RawMessage `json:"secrets"`
-
-			// UserData entries unique to this Region
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/userData
-			UserData json.RawMessage `json:"userData"`
-		} `json:"regions"`
+		Regions []RegionsEntry1 `json:"regions"`
 
 		// A scaling ratio of `0.2` means that the provisioner will attempt to keep
 		// the number of pending tasks around 20% of the provisioned capacity.
@@ -609,11 +435,254 @@ type (
 		WorkerType string `json:"workerType"`
 	}
 
+	// Instance Type configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items
+	InstanceTypesEntry struct {
+
+		// This number represents the number of tasks that this instance type
+		// is capable of running concurrently.  This is used by the provisioner
+		// to know how many pending tasks to offset a pending instance of this
+		// type by
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/capacity
+		Capacity float64 `json:"capacity"`
+
+		// InstanceType name for Amazon.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/instanceType
+		InstanceType string `json:"instanceType"`
+
+		// LaunchSpecification entries unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/launchSpec
+		LaunchSpec json.RawMessage `json:"launchSpec"`
+
+		// Scopes which should be included for this InstanceType.  Scopes must
+		// be composed of printable ASCII characters and spaces.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/scopes
+		Scopes []string `json:"scopes"`
+
+		// Static Secrets unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets"`
+
+		// UserData entries unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/userData
+		UserData json.RawMessage `json:"userData"`
+
+		// This number is a relative measure of performance between two instance
+		// types.  It is multiplied by the spot price from Amazon to figure out
+		// which instance type is the cheapest one
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/instanceTypes/items/properties/utility
+		Utility float64 `json:"utility"`
+	}
+
+	// Instance Type configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items
+	InstanceTypesEntry1 struct {
+
+		// This number represents the number of tasks that this instance type
+		// is capable of running concurrently.  This is used by the provisioner
+		// to know how many pending tasks to offset a pending instance of this
+		// type by
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/capacity
+		Capacity float64 `json:"capacity"`
+
+		// InstanceType name for Amazon.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/instanceType
+		InstanceType string `json:"instanceType"`
+
+		// LaunchSpecification entries unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/launchSpec
+		LaunchSpec json.RawMessage `json:"launchSpec"`
+
+		// Scopes which should be included for this InstanceType.  Scopes must
+		// be composed of printable ASCII characters and spaces.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/scopes
+		Scopes []string `json:"scopes"`
+
+		// Static Secrets unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets"`
+
+		// UserData entries unique to this InstanceType
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/userData
+		UserData json.RawMessage `json:"userData"`
+
+		// This number is a relative measure of performance between two instance
+		// types.  It is multiplied by the spot price from Amazon to figure out
+		// which instance type is the cheapest one
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/instanceTypes/items/properties/utility
+		Utility float64 `json:"utility"`
+	}
+
+	// LaunchSpecification entries unique to this Region
+	//
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// Per-region AMI ImageId
+	//  	//
+	//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+	//  	ImageID string `json:"ImageId"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
+	LaunchSpec json.RawMessage
+
+	// LaunchSpecification entries unique to this Region
+	//
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// Per-region AMI ImageId
+	//  	//
+	//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+	//  	ImageID string `json:"ImageId"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
+	LaunchSpec1 json.RawMessage
+
 	// See http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-summaries-response.json#
 	ListWorkerTypeSummariesResponse []WorkerTypeSummary
 
 	// See http://schemas.taskcluster.net/aws-provisioner/v1/list-worker-types-response.json#
 	ListWorkerTypes1 []string
+
+	// Region configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items
+	RegionsEntry struct {
+
+		// LaunchSpecification entries unique to this Region
+		//
+		// Defined properties:
+		//
+		//  struct {
+		//
+		//  	// Per-region AMI ImageId
+		//  	//
+		//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+		//  	ImageID string `json:"ImageId"`
+		//  }
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/launchSpec
+		LaunchSpec LaunchSpec `json:"launchSpec"`
+
+		// The Amazon AWS Region being configured.  Example: us-west-1
+		//
+		// Possible values:
+		//   * "us-west-2"
+		//   * "us-east-1"
+		//   * "us-east-2"
+		//   * "us-west-1"
+		//   * "eu-central-1"
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/region
+		Region string `json:"region"`
+
+		// Scopes which should be included for this Region.  Scopes must be
+		// composed of printable ASCII characters and spaces.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/scopes
+		Scopes []string `json:"scopes"`
+
+		// Static Secrets unique to this Region
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets"`
+
+		// UserData entries unique to this Region
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/create-worker-type-request.json#/properties/regions/items/properties/userData
+		UserData json.RawMessage `json:"userData"`
+	}
+
+	// Region configuration
+	//
+	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items
+	RegionsEntry1 struct {
+
+		// LaunchSpecification entries unique to this Region
+		//
+		// Defined properties:
+		//
+		//  struct {
+		//
+		//  	// Per-region AMI ImageId
+		//  	//
+		//  	// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec/properties/ImageId
+		//  	ImageID string `json:"ImageId"`
+		//  }
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/launchSpec
+		LaunchSpec LaunchSpec1 `json:"launchSpec"`
+
+		// The Amazon AWS Region being configured.  Example: us-west-1
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/region
+		Region string `json:"region"`
+
+		// Scopes which should be included for this Region.  Scopes must be
+		// composed of printable ASCII characters and spaces.
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/scopes
+		Scopes []string `json:"scopes"`
+
+		// Static Secrets unique to this Region
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/secrets
+		Secrets json.RawMessage `json:"secrets"`
+
+		// UserData entries unique to this Region
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/aws-provisioner/v1/get-worker-type-response.json#/properties/regions/items/properties/userData
+		UserData json.RawMessage `json:"userData"`
+	}
 
 	// A summary of a worker type's current state, expresed in terms of capacity.
 	//
@@ -651,6 +720,38 @@ func (this *GetAllLaunchSpecsResponse) MarshalJSON() ([]byte, error) {
 func (this *GetAllLaunchSpecsResponse) UnmarshalJSON(data []byte) error {
 	if this == nil {
 		return errors.New("GetAllLaunchSpecsResponse: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// LaunchSpec is of type json.RawMessage...
+func (this *LaunchSpec) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *LaunchSpec) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("LaunchSpec: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// LaunchSpec1 is of type json.RawMessage...
+func (this *LaunchSpec1) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *LaunchSpec1) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("LaunchSpec1: UnmarshalJSON on nil pointer")
 	}
 	*this = append((*this)[0:0], data...)
 	return nil

--- a/tcec2manager/tcec2manager.go
+++ b/tcec2manager/tcec2manager.go
@@ -32,7 +32,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // https://references.taskcluster.net/ec2-manager/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcec2manager
 

--- a/tcec2manager/types.go
+++ b/tcec2manager/types.go
@@ -4,90 +4,14 @@ package tcec2manager
 
 import (
 	"encoding/json"
+	"errors"
 
 	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
 type (
-	// This method returns a list of errors.  It currently gives the error code only
-	// because we're not sure of the security implications of exposing the full
-	// message.  We do store complete error messages, but are figuring out how to
-	// best expose them
-	//
-	// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#
-	Errors struct {
-
-		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors
-		Errors []struct {
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/az
-			Az string `json:"az,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/code
-			Code string `json:"code,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/instanceType
-			InstanceType string `json:"instanceType,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/message
-			Message string `json:"message,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/region
-			Region string `json:"region,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/time
-			Time tcclient.Time `json:"time,omitempty"`
-
-			// Possible values:
-			//   * "instance-request"
-			//   * "termination"
-			//
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/type
-			Type string `json:"type,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/workerType
-			WorkerType string `json:"workerType,omitempty"`
-		} `json:"errors,omitempty"`
-	}
-
-	// This method provides a summary of the health in the EC2 account being managed.
-	// Values for the overall account are provided, broken down by Region, Availability
-	// Zone and Instance Type.
-	//
-	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#
-	HealthOfTheEC2Account struct {
-
-		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth
-		RequestHealth []json.RawMessage `json:"requestHealth,omitempty"`
-
-		// An overview of currently running instances
-		//
-		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running
-		Running []struct {
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/az
-			Az string `json:"az,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/instanceType
-			InstanceType string `json:"instanceType,omitempty"`
-
-			// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/region
-			Region string `json:"region,omitempty"`
-
-			// The number of currently running instances in this configuration
-			//
-			// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/running
-			Running int64 `json:"running,omitempty"`
-		} `json:"running,omitempty"`
-
-		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth
-		TerminationHealth []json.RawMessage `json:"terminationHealth,omitempty"`
-	}
-
-	// A list of prices for EC2
-	//
-	// See http://schemas.taskcluster.net/ec2-manager/v1/prices.json#
-	ListOfPrices []struct {
+	// See http://schemas.taskcluster.net/ec2-manager/v1/prices.json#/items
+	Entry1 struct {
 
 		// EC2 instance type
 		//
@@ -117,10 +41,8 @@ type (
 		Zone string `json:"zone,omitempty"`
 	}
 
-	// A list of prices for EC2
-	//
-	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#
-	ListOfRestrictionsForPrices []struct {
+	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items
+	Entry3 struct {
 
 		// Possible values:
 		//   * "instanceType"
@@ -135,13 +57,126 @@ type (
 		Key string `json:"key,omitempty"`
 
 		// One of:
-		//   * Var
 		//   * Var1
 		//   * Var2
+		//   * Var3
 		//
 		// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction
 		Restriction json.RawMessage `json:"restriction,omitempty"`
 	}
+
+	// This method returns a list of errors.  It currently gives the error code only
+	// because we're not sure of the security implications of exposing the full
+	// message.  We do store complete error messages, but are figuring out how to
+	// best expose them
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#
+	Errors struct {
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors
+		Errors []ErrorsEntry `json:"errors,omitempty"`
+	}
+
+	// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items
+	ErrorsEntry struct {
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/az
+		Az string `json:"az,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/code
+		Code string `json:"code,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/instanceType
+		InstanceType string `json:"instanceType,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/message
+		Message string `json:"message,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/region
+		Region string `json:"region,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/time
+		Time tcclient.Time `json:"time,omitempty"`
+
+		// Possible values:
+		//   * "instance-request"
+		//   * "termination"
+		//
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/type
+		Type string `json:"type,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/errors.json#/properties/errors/items/properties/workerType
+		WorkerType string `json:"workerType,omitempty"`
+	}
+
+	// This method provides a summary of the health in the EC2 account being managed.
+	// Values for the overall account are provided, broken down by Region, Availability
+	// Zone and Instance Type.
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#
+	HealthOfTheEC2Account struct {
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth
+		RequestHealth []RequestHealthEntry `json:"requestHealth,omitempty"`
+
+		// An overview of currently running instances
+		//
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running
+		Running []RunningEntry `json:"running,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth
+		TerminationHealth []TerminationHealthEntry `json:"terminationHealth,omitempty"`
+	}
+
+	// This is an EC2-Manager specific wrapping of the request body for the
+	// upstream EC2 API.  Values from this are passed through verbatim.  A small
+	// number of checks are done on the data before making the call, as well as
+	// having some schema keys set to ensure certain values are either present
+	// or absent
+	//
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// This is the AMI Identifier for this spot request.  This image must
+	//  	// already exist and must be in the region of the request.  Note that
+	//  	// AMI images are per-region, so you must copy or regenerate the image
+	//  	// for each region.
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/ImageId
+	//  	ImageID string `json:"ImageId,omitempty"`
+	//
+	//  	// The instance type to use for this spot request
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/InstanceType
+	//  	InstanceType string `json:"InstanceType,omitempty"`
+	//
+	//  	// A valid EC2 KeyPair name.  The KeyPair must already exist
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/KeyName
+	//  	KeyName string `json:"KeyName,omitempty"`
+	//
+	//  	// This is a list of the security groups this image will use.  These
+	//  	// groups must already exist in the region.
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo/properties/SecurityGroups
+	//  	SecurityGroups []string `json:"SecurityGroups,omitempty"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo
+	LaunchInfo json.RawMessage
+
+	// A list of prices for EC2
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/prices.json#
+	ListOfPrices []Entry1
+
+	// A list of prices for EC2
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#
+	ListOfRestrictionsForPrices []Entry3
 
 	// A list of names of worker types
 	//
@@ -206,7 +241,7 @@ type (
 		// Additional properties allowed
 		//
 		// See http://schemas.taskcluster.net/ec2-manager/v1/run-instance-request.json#/properties/LaunchInfo
-		LaunchInfo json.RawMessage `json:"LaunchInfo,omitempty"`
+		LaunchInfo LaunchInfo `json:"LaunchInfo,omitempty"`
 
 		// The EC2 region in which this spot request is to be made.  This should be
 		// the lower case api-identifier.  For example `us-east-1`
@@ -240,7 +275,7 @@ type (
 	OverviewOfComputationalResources struct {
 
 		// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending
-		Pending []json.RawMessage `json:"pending,omitempty"`
+		Pending []PendingEntry `json:"pending,omitempty"`
 
 		// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/running
 		Running []interface{} `json:"running,omitempty"`
@@ -255,6 +290,108 @@ type (
 		Instances []interface{} `json:"instances,omitempty"`
 	}
 
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/count
+	//  	Count float64 `json:"count,omitempty"`
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/instanceType
+	//  	InstanceType string `json:"instanceType,omitempty"`
+	//
+	//  	// Possible values:
+	//  	//   * "instance"
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items/properties/type
+	//  	Type string `json:"type,omitempty"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/worker-type-resources.json#/properties/pending/items
+	PendingEntry json.RawMessage
+
+	// This is a list of outcomes for a specific region, availability zone and
+	// instance type.  These are calls to the EC2 runInstances method, which
+	// is how we request instances.  If a call to this method is successful,
+	// then we expect to get an instance to match
+	//
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/az
+	//  	Az string `json:"az,omitempty"`
+	//
+	//  	// The number of calls failed due to a misconfiguration of the worker type.  Due to the large number of error codes the EC2 API might return, this is a best effort categorization.  It covers codes which are like "Invalid%" using SQL pattern mattching on the codes from https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html It is not categorized by which field was invalid in this response
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/configuration_issue
+	//  	Configuration_Issue int64 `json:"configuration_issue,omitempty"`
+	//
+	//  	// The total number of calls which failed, inrespective of why
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/failed
+	//  	Failed int64 `json:"failed,omitempty"`
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/instanceType
+	//  	InstanceType string `json:"instanceType,omitempty"`
+	//
+	//  	// Number of runInstances calls which have failed because there aren't
+	//  	// enough hosts for the resources to be allocated.
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/insufficient_capacity
+	//  	Insufficient_Capacity int64 `json:"insufficient_capacity,omitempty"`
+	//
+	//  	// The number of calls which failed due to a limit being exceeded.
+	//  	// Due to the large number of error codes the EC2 API might return,
+	//  	// this is a best effort categorization.  It covers codes which are
+	//  	// like "%LimitExceeded" using SQL pattern mattching, but not
+	//  	// RequestLimitExceeded on the codes from
+	//  	// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
+	//  	// It is not categorized by which limit was exceeded in this response
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/limit_exceeded
+	//  	Limit_Exceeded int64 `json:"limit_exceeded,omitempty"`
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/region
+	//  	Region string `json:"region,omitempty"`
+	//
+	//  	// The number of instances which have been requested successfully
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/successful
+	//  	Successful int64 `json:"successful,omitempty"`
+	//
+	//  	// Number of calls which have been throttled in this region.  These
+	//  	// are errors with the code RequestLimitExceeded.
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items/properties/throttled_calls
+	//  	Throttled_Calls int64 `json:"throttled_calls,omitempty"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/requestHealth/items
+	RequestHealthEntry json.RawMessage
+
+	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items
+	RunningEntry struct {
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/az
+		Az string `json:"az,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/instanceType
+		InstanceType string `json:"instanceType,omitempty"`
+
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/region
+		Region string `json:"region,omitempty"`
+
+		// The number of currently running instances in this configuration
+		//
+		// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/running/items/properties/running
+		Running int64 `json:"running,omitempty"`
+	}
+
 	// See http://schemas.taskcluster.net/ec2-manager/v1/create-key-pair.json#
 	SSHPublicKey struct {
 
@@ -266,12 +403,152 @@ type (
 		Pubkey string `json:"pubkey,omitempty"`
 	}
 
+	// This is a list of summaries of instances which have terminated
+	//
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/az
+	//  	Az string `json:"az,omitempty"`
+	//
+	//  	// A count of the instances which were shutdown cleanty.  For the
+	//  	// purposes of this API, a clean shutdown is one which was initiated
+	//  	// by us.  This includes API shutdowns or workers ending themselves.
+	//  	// It does not mean the actual workload ran successfully, rather that
+	//  	// we chose to terminate it
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/clean_shutdown
+	//  	Clean_Shutdown int64 `json:"clean_shutdown,omitempty"`
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/instanceType
+	//  	InstanceType string `json:"instanceType,omitempty"`
+	//
+	//  	// The number of instances which were terminated due to a lack of
+	//  	// capacity.  More than likely, this will always be zero because the
+	//  	// new spot service is now synchronous, so runInstances calls should
+	//  	// fail
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/insufficient_capacity
+	//  	Insufficient_Capacity int64 `json:"insufficient_capacity,omitempty"`
+	//
+	//  	// The number of instances which were terminated due to not being able
+	//  	// to find the AMI
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/missing_ami
+	//  	Missing_Ami int64 `json:"missing_ami,omitempty"`
+	//
+	//  	// The number of terminations which we cannot find a code.  This means
+	//  	// we cannot determine whether this should be classified as a good or
+	//  	// bad outcome.  The specific reason is that the code which polls for
+	//  	// termination reason was not able to run before the EC2 API dropped
+	//  	// the instance from its database
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/no_code
+	//  	No_Code int64 `json:"no_code,omitempty"`
+	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/region
+	//  	Region string `json:"region,omitempty"`
+	//
+	//  	// The number of instances which were killed by the spot service
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/spot_kill
+	//  	Spot_Kill int64 `json:"spot_kill,omitempty"`
+	//
+	//  	// The number of instances which failed to start, either because of an
+	//  	// error on our side or on the EC2 side
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/startup_failed
+	//  	Startup_Failed int64 `json:"startup_failed,omitempty"`
+	//
+	//  	// The number of terminations which have a code which this code does
+	//  	// not recognize
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/unknown_code
+	//  	Unknown_Code int64 `json:"unknown_code,omitempty"`
+	//
+	//  	// The number of instances which were terminated due to exceeding the
+	//  	// limit for number of ebs volumes
+	//  	//
+	//  	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items/properties/volume_limit_exceeded
+	//  	Volume_Limit_Exceeded int64 `json:"volume_limit_exceeded,omitempty"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/ec2-manager/v1/health.json#/properties/terminationHealth/items
+	TerminationHealthEntry json.RawMessage
+
 	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[0]
-	Var float64
+	Var1 float64
 
 	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[1]
-	Var1 string
+	Var2 string
 
 	// See http://schemas.taskcluster.net/ec2-manager/v1/prices-request.json#/items/properties/restriction/oneOf[2]
-	Var2 []string
+	Var3 []string
 )
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// LaunchInfo is of type json.RawMessage...
+func (this *LaunchInfo) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *LaunchInfo) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("LaunchInfo: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// PendingEntry is of type json.RawMessage...
+func (this *PendingEntry) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *PendingEntry) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("PendingEntry: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// RequestHealthEntry is of type json.RawMessage...
+func (this *RequestHealthEntry) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *RequestHealthEntry) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("RequestHealthEntry: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// TerminationHealthEntry is of type json.RawMessage...
+func (this *TerminationHealthEntry) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *TerminationHealthEntry) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("TerminationHealthEntry: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}

--- a/tcgithub/tcgithub.go
+++ b/tcgithub/tcgithub.go
@@ -40,7 +40,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/github/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcgithub
 

--- a/tcgithub/types.go
+++ b/tcgithub/types.go
@@ -18,81 +18,84 @@ type (
 		// A simple list of builds.
 		//
 		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds
-		Builds []struct {
-
-			// The initial creation time of the build. This is when it became pending.
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/created
-			Created tcclient.Time `json:"created"`
-
-			// The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
-			//
-			// One of:
-			//   * Var
-			//   * Var1
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId
-			EventID string `json:"eventId"`
-
-			// Type of Github event that triggered the build (i.e. push, pull_request.opened).
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventType
-			EventType string `json:"eventType"`
-
-			// Github organization associated with the build.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_%]*)$
-			// Min length: 1
-			// Max length: 100
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/organization
-			Organization string `json:"organization"`
-
-			// Github repository associated with the build.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_%]*)$
-			// Min length: 1
-			// Max length: 100
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/repository
-			Repository string `json:"repository"`
-
-			// Github revision associated with the build.
-			//
-			// Min length: 40
-			// Max length: 40
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/sha
-			Sha string `json:"sha"`
-
-			// Github status associated with the build.
-			//
-			// Possible values:
-			//   * "pending"
-			//   * "success"
-			//   * "error"
-			//   * "failure"
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/state
-			State string `json:"state"`
-
-			// Taskcluster task-group associated with the build.
-			//
-			// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/taskGroupId
-			TaskGroupID string `json:"taskGroupId"`
-
-			// The last updated of the build. If it is done, this is when it finished.
-			//
-			// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/updated
-			Updated tcclient.Time `json:"updated"`
-		} `json:"builds"`
+		Builds []BuildsEntry `json:"builds"`
 
 		// Passed back from Azure to allow us to page through long result sets.
 		//
 		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/continuationToken
 		ContinuationToken string `json:"continuationToken,omitempty"`
+	}
+
+	// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items
+	BuildsEntry struct {
+
+		// The initial creation time of the build. This is when it became pending.
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/created
+		Created tcclient.Time `json:"created"`
+
+		// The GitHub webhook deliveryId. Extracted from the header 'X-GitHub-Delivery'
+		//
+		// One of:
+		//   * Var
+		//   * Var1
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventId
+		EventID string `json:"eventId"`
+
+		// Type of Github event that triggered the build (i.e. push, pull_request.opened).
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/eventType
+		EventType string `json:"eventType"`
+
+		// Github organization associated with the build.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_%]*)$
+		// Min length: 1
+		// Max length: 100
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/organization
+		Organization string `json:"organization"`
+
+		// Github repository associated with the build.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_%]*)$
+		// Min length: 1
+		// Max length: 100
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/repository
+		Repository string `json:"repository"`
+
+		// Github revision associated with the build.
+		//
+		// Min length: 40
+		// Max length: 40
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/sha
+		Sha string `json:"sha"`
+
+		// Github status associated with the build.
+		//
+		// Possible values:
+		//   * "pending"
+		//   * "success"
+		//   * "error"
+		//   * "failure"
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/state
+		State string `json:"state"`
+
+		// Taskcluster task-group associated with the build.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/taskGroupId
+		TaskGroupID string `json:"taskGroupId"`
+
+		// The last updated of the build. If it is done, this is when it finished.
+		//
+		// See http://schemas.taskcluster.net/github/v1/build-list.json#/properties/builds/items/properties/updated
+		Updated tcclient.Time `json:"updated"`
 	}
 
 	// Write a new comment on a GitHub Issue or Pull Request.

--- a/tchooks/tchooks.go
+++ b/tchooks/tchooks.go
@@ -50,7 +50,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/hooks/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tchooks
 

--- a/tchooks/types.go
+++ b/tchooks/types.go
@@ -69,36 +69,7 @@ type (
 		HookID string `json:"hookId,omitempty"`
 
 		// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata
-		Metadata struct {
-
-			// Long-form of the hook's purpose and behavior
-			//
-			// Max length: 32768
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/description
-			Description string `json:"description"`
-
-			// Whether to email the owner on an error creating the task.
-			//
-			// Default:    true
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/emailOnError
-			EmailOnError bool `json:"emailOnError,omitempty"`
-
-			// Human readable name of the hook
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/name
-			Name string `json:"name"`
-
-			// Email of the person or group responsible for this hook.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/owner
-			Owner string `json:"owner"`
-		} `json:"metadata"`
+		Metadata Metadata1 `json:"metadata"`
 
 		// Definition of the times at which a hook will result in creation of a task.
 		// If several patterns are specified, tasks will be created at any time
@@ -161,36 +132,7 @@ type (
 		HookID string `json:"hookId"`
 
 		// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata
-		Metadata struct {
-
-			// Long-form of the hook's purpose and behavior
-			//
-			// Max length: 32768
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/description
-			Description string `json:"description"`
-
-			// Whether to email the owner on an error creating the task.
-			//
-			// Default:    true
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/emailOnError
-			EmailOnError bool `json:"emailOnError,omitempty"`
-
-			// Human readable name of the hook
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/name
-			Name string `json:"name"`
-
-			// Email of the person or group responsible for this hook.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/owner
-			Owner string `json:"owner"`
-		} `json:"metadata"`
+		Metadata Metadata `json:"metadata"`
 
 		// Definition of the times at which a hook will result in creation of a task.
 		// If several patterns are specified, tasks will be created at any time
@@ -274,6 +216,70 @@ type (
 		NextScheduledDate tcclient.Time `json:"nextScheduledDate,omitempty"`
 	}
 
+	// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata
+	Metadata struct {
+
+		// Long-form of the hook's purpose and behavior
+		//
+		// Max length: 32768
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/description
+		Description string `json:"description"`
+
+		// Whether to email the owner on an error creating the task.
+		//
+		// Default:    true
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/emailOnError
+		EmailOnError bool `json:"emailOnError,omitempty"`
+
+		// Human readable name of the hook
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/name
+		Name string `json:"name"`
+
+		// Email of the person or group responsible for this hook.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/hook-definition.json#/properties/metadata/properties/owner
+		Owner string `json:"owner"`
+	}
+
+	// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata
+	Metadata1 struct {
+
+		// Long-form of the hook's purpose and behavior
+		//
+		// Max length: 32768
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/description
+		Description string `json:"description"`
+
+		// Whether to email the owner on an error creating the task.
+		//
+		// Default:    true
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/emailOnError
+		EmailOnError bool `json:"emailOnError,omitempty"`
+
+		// Human readable name of the hook
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/name
+		Name string `json:"name"`
+
+		// Email of the person or group responsible for this hook.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/create-hook-request.json#/properties/metadata/properties/owner
+		Owner string `json:"owner"`
+	}
+
 	// Information about no firing of the hook (e.g., a new hook)
 	//
 	// See http://schemas.taskcluster.net/hooks/v1/hook-status.json#/properties/lastFire/oneOf[2]
@@ -286,6 +292,115 @@ type (
 		Result string `json:"result"`
 	}
 
+	// JSON object with information about a run
+	//
+	// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items
+	RunInformation struct {
+
+		// Reason for the creation of this run,
+		// **more reasons may be added in the future**.
+		//
+		// Possible values:
+		//   * "scheduled"
+		//   * "retry"
+		//   * "task-retry"
+		//   * "rerun"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonCreated
+		ReasonCreated string `json:"reasonCreated"`
+
+		// Reason that run was resolved, this is mainly
+		// useful for runs resolved as `exception`.
+		// Note, **more reasons may be added in the future**, also this
+		// property is only available after the run is resolved.
+		//
+		// Possible values:
+		//   * "completed"
+		//   * "failed"
+		//   * "deadline-exceeded"
+		//   * "canceled"
+		//   * "superseded"
+		//   * "claim-expired"
+		//   * "worker-shutdown"
+		//   * "malformed-payload"
+		//   * "resource-unavailable"
+		//   * "internal-error"
+		//   * "intermittent-task"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonResolved
+		ReasonResolved string `json:"reasonResolved,omitempty"`
+
+		// Date-time at which this run was resolved, ie. when the run changed
+		// state from `running` to either `completed`, `failed` or `exception`.
+		// This property is only present after the run as been resolved.
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/resolved
+		Resolved tcclient.Time `json:"resolved,omitempty"`
+
+		// Id of this task run, `run-id`s always starts from `0`
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/runId
+		RunID int64 `json:"runId"`
+
+		// Date-time at which this run was scheduled, ie. when the run was
+		// created in state `pending`.
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/scheduled
+		Scheduled tcclient.Time `json:"scheduled"`
+
+		// Date-time at which this run was claimed, ie. when the run changed
+		// state from `pending` to `running`. This property is only present
+		// after the run has been claimed.
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/started
+		Started tcclient.Time `json:"started,omitempty"`
+
+		// State of this run
+		//
+		// Possible values:
+		//   * "pending"
+		//   * "running"
+		//   * "completed"
+		//   * "failed"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/state
+		State string `json:"state"`
+
+		// Time at which the run expires and is resolved as `failed`, if the
+		// run isn't reclaimed. Note, only present after the run has been
+		// claimed.
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/takenUntil
+		TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
+
+		// Identifier for group that worker who executes this run is a part of,
+		// this identifier is mainly used for efficient routing.
+		// Note, this property is only present after the run is claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerGroup
+		WorkerGroup string `json:"workerGroup,omitempty"`
+
+		// Identifier for worker evaluating this run within given
+		// `workerGroup`. Note, this property is only available after the run
+		// has been claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerId
+		WorkerID string `json:"workerId,omitempty"`
+	}
+
 	// A list of cron-style definitions to represent a set of moments in (UTC) time.
 	// If several patterns are specified, a given moment in time represented by
 	// more than one pattern is considered only to be counted once, in other words
@@ -295,6 +410,96 @@ type (
 	//
 	// See http://schemas.taskcluster.net/hooks/v1/schedule.json#
 	Schedule []string
+
+	// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status
+	Status struct {
+
+		// Use of this field is deprecated; use `deadline: {$fromNow: ..}` in the task template instead.
+		//
+		// Default:    "1 day"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/deadline
+		Deadline string `json:"deadline"`
+
+		// Use of this field is deprecated; use `expires: {$fromNow: ..}` in the task template instead.
+		//
+		// Default:    "3 months"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/expires
+		Expires string `json:"expires"`
+
+		// Unique identifier for the provisioner that this task must be scheduled on
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/provisionerId
+		ProvisionerID string `json:"provisionerId"`
+
+		// Number of retries left for the task in case of infrastructure issues
+		//
+		// Mininum:    0
+		// Maximum:    999
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/retriesLeft
+		RetriesLeft int64 `json:"retriesLeft"`
+
+		// List of runs, ordered so that index `i` has `runId == i`
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs
+		Runs []RunInformation `json:"runs"`
+
+		// Identifier for the scheduler that _defined_ this task.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/schedulerId
+		SchedulerID string `json:"schedulerId"`
+
+		// State of this task. This is just an auxiliary property derived from state
+		// of latests run, or `unscheduled` if none.
+		//
+		// Possible values:
+		//   * "unscheduled"
+		//   * "pending"
+		//   * "running"
+		//   * "completed"
+		//   * "failed"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/state
+		State string `json:"state"`
+
+		// Identifier for a group of tasks scheduled together with this task, by
+		// scheduler identified by `schedulerId`. For tasks scheduled by the
+		// task-graph scheduler, this is the `taskGraphId`.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskGroupId
+		TaskGroupID string `json:"taskGroupId"`
+
+		// Unique task identifier, this is UUID encoded as
+		// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+		// stripped of `=` padding.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskId
+		TaskID string `json:"taskId"`
+
+		// Identifier for worker type within the specified provisioner
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/workerType
+		WorkerType string `json:"workerType"`
+	}
 
 	// Information about a successful firing of the hook
 	//
@@ -326,198 +531,7 @@ type (
 	TaskStatusStructure struct {
 
 		// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status
-		Status struct {
-
-			// Use of this field is deprecated; use `deadline: {$fromNow: ..}` in the task template instead.
-			//
-			// Default:    "1 day"
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/deadline
-			Deadline string `json:"deadline"`
-
-			// Use of this field is deprecated; use `expires: {$fromNow: ..}` in the task template instead.
-			//
-			// Default:    "3 months"
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/expires
-			Expires string `json:"expires"`
-
-			// Unique identifier for the provisioner that this task must be scheduled on
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/provisionerId
-			ProvisionerID string `json:"provisionerId"`
-
-			// Number of retries left for the task in case of infrastructure issues
-			//
-			// Mininum:    0
-			// Maximum:    999
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/retriesLeft
-			RetriesLeft int64 `json:"retriesLeft"`
-
-			// List of runs, ordered so that index `i` has `runId == i`
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs
-			Runs []struct {
-
-				// Reason for the creation of this run,
-				// **more reasons may be added in the future**.
-				//
-				// Possible values:
-				//   * "scheduled"
-				//   * "retry"
-				//   * "task-retry"
-				//   * "rerun"
-				//   * "exception"
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonCreated
-				ReasonCreated string `json:"reasonCreated"`
-
-				// Reason that run was resolved, this is mainly
-				// useful for runs resolved as `exception`.
-				// Note, **more reasons may be added in the future**, also this
-				// property is only available after the run is resolved.
-				//
-				// Possible values:
-				//   * "completed"
-				//   * "failed"
-				//   * "deadline-exceeded"
-				//   * "canceled"
-				//   * "superseded"
-				//   * "claim-expired"
-				//   * "worker-shutdown"
-				//   * "malformed-payload"
-				//   * "resource-unavailable"
-				//   * "internal-error"
-				//   * "intermittent-task"
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/reasonResolved
-				ReasonResolved string `json:"reasonResolved,omitempty"`
-
-				// Date-time at which this run was resolved, ie. when the run changed
-				// state from `running` to either `completed`, `failed` or `exception`.
-				// This property is only present after the run as been resolved.
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/resolved
-				Resolved tcclient.Time `json:"resolved,omitempty"`
-
-				// Id of this task run, `run-id`s always starts from `0`
-				//
-				// Mininum:    0
-				// Maximum:    1000
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/runId
-				RunID int64 `json:"runId"`
-
-				// Date-time at which this run was scheduled, ie. when the run was
-				// created in state `pending`.
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/scheduled
-				Scheduled tcclient.Time `json:"scheduled"`
-
-				// Date-time at which this run was claimed, ie. when the run changed
-				// state from `pending` to `running`. This property is only present
-				// after the run has been claimed.
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/started
-				Started tcclient.Time `json:"started,omitempty"`
-
-				// State of this run
-				//
-				// Possible values:
-				//   * "pending"
-				//   * "running"
-				//   * "completed"
-				//   * "failed"
-				//   * "exception"
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/state
-				State string `json:"state"`
-
-				// Time at which the run expires and is resolved as `failed`, if the
-				// run isn't reclaimed. Note, only present after the run has been
-				// claimed.
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/takenUntil
-				TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
-
-				// Identifier for group that worker who executes this run is a part of,
-				// this identifier is mainly used for efficient routing.
-				// Note, this property is only present after the run is claimed.
-				//
-				// Syntax:     ^([a-zA-Z0-9-_]*)$
-				// Min length: 1
-				// Max length: 22
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerGroup
-				WorkerGroup string `json:"workerGroup,omitempty"`
-
-				// Identifier for worker evaluating this run within given
-				// `workerGroup`. Note, this property is only available after the run
-				// has been claimed.
-				//
-				// Syntax:     ^([a-zA-Z0-9-_]*)$
-				// Min length: 1
-				// Max length: 22
-				//
-				// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/runs/items/properties/workerId
-				WorkerID string `json:"workerId,omitempty"`
-			} `json:"runs"`
-
-			// Identifier for the scheduler that _defined_ this task.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/schedulerId
-			SchedulerID string `json:"schedulerId"`
-
-			// State of this task. This is just an auxiliary property derived from state
-			// of latests run, or `unscheduled` if none.
-			//
-			// Possible values:
-			//   * "unscheduled"
-			//   * "pending"
-			//   * "running"
-			//   * "completed"
-			//   * "failed"
-			//   * "exception"
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/state
-			State string `json:"state"`
-
-			// Identifier for a group of tasks scheduled together with this task, by
-			// scheduler identified by `schedulerId`. For tasks scheduled by the
-			// task-graph scheduler, this is the `taskGraphId`.
-			//
-			// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskGroupId
-			TaskGroupID string `json:"taskGroupId"`
-
-			// Unique task identifier, this is UUID encoded as
-			// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-			// stripped of `=` padding.
-			//
-			// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/taskId
-			TaskID string `json:"taskId"`
-
-			// Identifier for worker type within the specified provisioner
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/hooks/v1/task-status.json#/properties/status/properties/workerType
-			WorkerType string `json:"workerType"`
-		} `json:"status"`
+		Status Status `json:"status"`
 	}
 
 	// Trigger context

--- a/tcindex/tcindex.go
+++ b/tcindex/tcindex.go
@@ -123,7 +123,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/index/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcindex
 

--- a/tcindex/types.go
+++ b/tcindex/types.go
@@ -101,27 +101,7 @@ type (
 		// List of namespaces.
 		//
 		// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces
-		Namespaces []struct {
-
-			// Date at which this entry, and by implication all entries below it,
-			// expires from the task index.
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/expires
-			Expires tcclient.Time `json:"expires"`
-
-			// Name of namespace within it's parent namespace.
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/name
-			Name string `json:"name"`
-
-			// Fully qualified name of the namespace, you can use this to list
-			// namespaces or tasks under this namespace.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/namespace
-			Namespace string `json:"namespace"`
-		} `json:"namespaces"`
+		Namespaces []Namespace `json:"namespaces"`
 	}
 
 	// Representation of an indexed task.
@@ -139,42 +119,72 @@ type (
 		// List of tasks.
 		//
 		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks
-		Tasks []struct {
+		Tasks []Task `json:"tasks"`
+	}
 
-			// Data that was reported with the task. This is an arbitrary JSON
-			// object.
-			//
-			// Additional properties allowed
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/data
-			Data json.RawMessage `json:"data"`
+	// Representation of a namespace that contains indexed tasks.
+	//
+	// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items
+	Namespace struct {
 
-			// Date at which this entry expires from the task index.
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/expires
-			Expires tcclient.Time `json:"expires"`
+		// Date at which this entry, and by implication all entries below it,
+		// expires from the task index.
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/expires
+		Expires tcclient.Time `json:"expires"`
 
-			// Index path of the task.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/namespace
-			Namespace string `json:"namespace"`
+		// Name of namespace within it's parent namespace.
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/name
+		Name string `json:"name"`
 
-			// If multiple tasks are indexed with the same `namespace` the task
-			// with the highest `rank` will be stored and returned in later
-			// requests. If two tasks has the same `rank` the latest task will be
-			// stored.
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/rank
-			Rank float64 `json:"rank"`
+		// Fully qualified name of the namespace, you can use this to list
+		// namespaces or tasks under this namespace.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-namespaces-response.json#/properties/namespaces/items/properties/namespace
+		Namespace string `json:"namespace"`
+	}
 
-			// Unique task identifier for the task currently indexed at `namespace`.
-			//
-			// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-			//
-			// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/taskId
-			TaskID string `json:"taskId"`
-		} `json:"tasks"`
+	// Representation of a task.
+	//
+	// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items
+	Task struct {
+
+		// Data that was reported with the task. This is an arbitrary JSON
+		// object.
+		//
+		// Additional properties allowed
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/data
+		Data json.RawMessage `json:"data"`
+
+		// Date at which this entry expires from the task index.
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/expires
+		Expires tcclient.Time `json:"expires"`
+
+		// Index path of the task.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/namespace
+		Namespace string `json:"namespace"`
+
+		// If multiple tasks are indexed with the same `namespace` the task
+		// with the highest `rank` will be stored and returned in later
+		// requests. If two tasks has the same `rank` the latest task will be
+		// stored.
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/rank
+		Rank float64 `json:"rank"`
+
+		// Unique task identifier for the task currently indexed at `namespace`.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/index/v1/list-tasks-response.json#/properties/tasks/items/properties/taskId
+		TaskID string `json:"taskId"`
 	}
 )

--- a/tclogin/tclogin.go
+++ b/tclogin/tclogin.go
@@ -33,7 +33,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/login/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tclogin
 

--- a/tclogin/types.go
+++ b/tclogin/types.go
@@ -15,26 +15,31 @@ type (
 		// Taskcluster credentials. Note that the credentials may not contain a certificate!
 		//
 		// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials
-		Credentials struct {
-
-			// Syntax:     ^[a-zA-Z0-9_-]{22,66}$
-			//
-			// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/accessToken
-			AccessToken string `json:"accessToken"`
-
-			// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/certificate
-			Certificate string `json:"certificate,omitempty"`
-
-			// Syntax:     ^[A-Za-z0-9!@/:.+|_-]+$
-			//
-			// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/clientId
-			ClientID string `json:"clientId"`
-		} `json:"credentials,omitempty"`
+		Credentials TaskclusterCredentials `json:"credentials,omitempty"`
 
 		// Time after which the credentials are no longer valid.  Callers should
 		// call `oidcCredentials` again to get fresh credentials before this time.
 		//
 		// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/expires
 		Expires tcclient.Time `json:"expires,omitempty"`
+	}
+
+	// Taskcluster credentials. Note that the credentials may not contain a certificate!
+	//
+	// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials
+	TaskclusterCredentials struct {
+
+		// Syntax:     ^[a-zA-Z0-9_-]{22,66}$
+		//
+		// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/accessToken
+		AccessToken string `json:"accessToken"`
+
+		// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/certificate
+		Certificate string `json:"certificate,omitempty"`
+
+		// Syntax:     ^[A-Za-z0-9!@/:.+|_-]+$
+		//
+		// See http://schemas.taskcluster.net/login/v1/oidc-credentials-response.json#/properties/credentials/properties/clientId
+		ClientID string `json:"clientId"`
 	}
 )

--- a/tcnotify/tcnotify.go
+++ b/tcnotify/tcnotify.go
@@ -34,7 +34,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/notify/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcnotify
 

--- a/tcnotify/types.go
+++ b/tcnotify/types.go
@@ -8,6 +8,28 @@ import (
 )
 
 type (
+	// Optional link that can be added as a button to the email.
+	//
+	// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link
+	Link struct {
+
+		// Where the link should point to.
+		//
+		// Min length: 1
+		// Max length: 1024
+		//
+		// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/href
+		Href string `json:"href"`
+
+		// Text to display on link.
+		//
+		// Min length: 1
+		// Max length: 40
+		//
+		// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/text
+		Text string `json:"text"`
+	}
+
 	// Request to post a message on IRC.
 	//
 	// One of:
@@ -87,24 +109,7 @@ type (
 		// Optional link that can be added as a button to the email.
 		//
 		// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link
-		Link struct {
-
-			// Where the link should point to.
-			//
-			// Min length: 1
-			// Max length: 1024
-			//
-			// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/href
-			Href string `json:"href"`
-
-			// Text to display on link.
-			//
-			// Min length: 1
-			// Max length: 40
-			//
-			// See http://schemas.taskcluster.net/notify/v1/email-request.json#/properties/link/properties/text
-			Text string `json:"text"`
-		} `json:"link,omitempty"`
+		Link Link `json:"link,omitempty"`
 
 		// Reply-to e-mail (this property is optional)
 		//

--- a/tcpurgecache/tcpurgecache.go
+++ b/tcpurgecache/tcpurgecache.go
@@ -37,7 +37,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/purge-cache/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcpurgecache
 

--- a/tcpurgecache/types.go
+++ b/tcpurgecache/types.go
@@ -20,28 +20,7 @@ type (
 		// A simple list of purge-cache requests.
 		//
 		// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests
-		Requests []struct {
-
-			// All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/before
-			Before tcclient.Time `json:"before"`
-
-			// Name of cache to purge.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/cacheName
-			CacheName string `json:"cacheName"`
-
-			// ProvisionerId associated with the workerType.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
-			ProvisionerID string `json:"provisionerId"`
-
-			// Workertype cache exists on.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/workerType
-			WorkerType string `json:"workerType"`
-		} `json:"requests"`
+		Requests []RequestsEntry `json:"requests"`
 	}
 
 	// A list of currently open purge-cache requests.
@@ -57,28 +36,7 @@ type (
 		// A simple list of purge-cache requests.
 		//
 		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests
-		Requests []struct {
-
-			// All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/before
-			Before tcclient.Time `json:"before"`
-
-			// Name of cache to purge.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/cacheName
-			CacheName string `json:"cacheName"`
-
-			// ProvisionerId associated with the workerType.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
-			ProvisionerID string `json:"provisionerId"`
-
-			// Workertype cache exists on.
-			//
-			// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/workerType
-			WorkerType string `json:"workerType"`
-		} `json:"requests"`
+		Requests []RequestsEntry1 `json:"requests"`
 	}
 
 	// Request that a message be published to purge a specific cache.
@@ -92,5 +50,53 @@ type (
 		//
 		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request.json#/properties/cacheName
 		CacheName string `json:"cacheName"`
+	}
+
+	// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items
+	RequestsEntry struct {
+
+		// All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/before
+		Before tcclient.Time `json:"before"`
+
+		// Name of cache to purge.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/cacheName
+		CacheName string `json:"cacheName"`
+
+		// ProvisionerId associated with the workerType.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
+		ProvisionerID string `json:"provisionerId"`
+
+		// Workertype cache exists on.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/all-purge-cache-request-list.json#/properties/requests/items/properties/workerType
+		WorkerType string `json:"workerType"`
+	}
+
+	// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items
+	RequestsEntry1 struct {
+
+		// All caches that match this provisionerId, workerType, and cacheName must be destroyed if they were created _before_ this time.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/before
+		Before tcclient.Time `json:"before"`
+
+		// Name of cache to purge.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/cacheName
+		CacheName string `json:"cacheName"`
+
+		// ProvisionerId associated with the workerType.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/provisionerId
+		ProvisionerID string `json:"provisionerId"`
+
+		// Workertype cache exists on.
+		//
+		// See http://schemas.taskcluster.net/purge-cache/v1/purge-cache-request-list.json#/properties/requests/items/properties/workerType
+		WorkerType string `json:"workerType"`
 	}
 )

--- a/tcqueue/tcqueue.go
+++ b/tcqueue/tcqueue.go
@@ -40,7 +40,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/queue/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcqueue
 

--- a/tcqueue/types.go
+++ b/tcqueue/types.go
@@ -10,6 +10,306 @@ import (
 )
 
 type (
+	// Actions provide a generic mechanism to expose additional features of a
+	// provisioner, worker type, or worker to Taskcluster clients.
+	//
+	// An action is comprised of metadata describing the feature it exposes,
+	// together with a webhook for triggering it.
+	//
+	// The Taskcluster tools site, for example, retrieves actions when displaying
+	// provisioners, worker types and workers. It presents the provisioner/worker
+	// type/worker specific actions to the user. When the user triggers an action,
+	// the web client takes the registered webhook, substitutes parameters into the
+	// URL (see `url`), signs the requests with the Taskcluster credentials of the
+	// user operating the web interface, and issues the HTTP request.
+	//
+	// The level to which the action relates (provisioner, worker type, worker) is
+	// called the action context. All actions, regardless of the action contexts,
+	// are registered against the provisioner when calling
+	// `queue.declareProvisioner`.
+	//
+	// The action context is used by the web client to determine where in the web
+	// interface to present the action to the user as follows:
+	//
+	// | `context`   | Tool where action is displayed |
+	// |-------------|--------------------------------|
+	// | provisioner | Provisioner Explorer           |
+	// | worker-type | Workers Explorer               |
+	// | worker      | Worker Explorer                |
+	//
+	// See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+	// for more information.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items
+	Actions1 struct {
+
+		// Only actions with the context `worker-type` are included.
+		//
+		// Possible values:
+		//   * "worker-type"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/context
+		Context string `json:"context"`
+
+		// Description of the provisioner.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/description
+		Description string `json:"description"`
+
+		// Method to indicate the desired action to be performed for a given resource.
+		//
+		// Possible values:
+		//   * "POST"
+		//   * "PUT"
+		//   * "DELETE"
+		//   * "PATCH"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/method
+		Method string `json:"method"`
+
+		// Short names for things like logging/error messages.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/name
+		Name string `json:"name"`
+
+		// Appropriate title for any sort of Modal prompt.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/title
+		Title json.RawMessage `json:"title"`
+
+		// When an action is triggered, a request is made using the `url` and `method`.
+		// Depending on the `context`, the following parameters will be substituted in the url:
+		//
+		// | `context`   | Path parameters                                          |
+		// |-------------|----------------------------------------------------------|
+		// | provisioner | <provisionerId>                                          |
+		// | worker-type | <provisionerId>, <workerType>                            |
+		// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+		//
+		// _Note: The request needs to be signed with the user's Taskcluster credentials._
+		//
+		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/url
+		URL string `json:"url"`
+	}
+
+	// Actions provide a generic mechanism to expose additional features of a
+	// provisioner, worker type, or worker to Taskcluster clients.
+	//
+	// An action is comprised of metadata describing the feature it exposes,
+	// together with a webhook for triggering it.
+	//
+	// The Taskcluster tools site, for example, retrieves actions when displaying
+	// provisioners, worker types and workers. It presents the provisioner/worker
+	// type/worker specific actions to the user. When the user triggers an action,
+	// the web client takes the registered webhook, substitutes parameters into the
+	// URL (see `url`), signs the requests with the Taskcluster credentials of the
+	// user operating the web interface, and issues the HTTP request.
+	//
+	// The level to which the action relates (provisioner, worker type, worker) is
+	// called the action context. All actions, regardless of the action contexts,
+	// are registered against the provisioner when calling
+	// `queue.declareProvisioner`.
+	//
+	// The action context is used by the web client to determine where in the web
+	// interface to present the action to the user as follows:
+	//
+	// | `context`   | Tool where action is displayed |
+	// |-------------|--------------------------------|
+	// | provisioner | Provisioner Explorer           |
+	// | worker-type | Workers Explorer               |
+	// | worker      | Worker Explorer                |
+	//
+	// See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+	// for more information.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items
+	Actions2 struct {
+
+		// Only actions with the context `worker` are included.
+		//
+		// Possible values:
+		//   * "worker"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/context
+		Context string `json:"context"`
+
+		// Description of the provisioner.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/description
+		Description string `json:"description"`
+
+		// Method to indicate the desired action to be performed for a given resource.
+		//
+		// Possible values:
+		//   * "POST"
+		//   * "PUT"
+		//   * "DELETE"
+		//   * "PATCH"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/method
+		Method string `json:"method"`
+
+		// Short names for things like logging/error messages.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/name
+		Name string `json:"name"`
+
+		// Appropriate title for any sort of Modal prompt.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/title
+		Title json.RawMessage `json:"title"`
+
+		// When an action is triggered, a request is made using the `url` and `method`.
+		// Depending on the `context`, the following parameters will be substituted in the url:
+		//
+		// | `context`   | Path parameters                                          |
+		// |-------------|----------------------------------------------------------|
+		// | provisioner | <provisionerId>                                          |
+		// | worker-type | <provisionerId>, <workerType>                            |
+		// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+		//
+		// _Note: The request needs to be signed with the user's Taskcluster credentials._
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/url
+		URL string `json:"url"`
+	}
+
+	// See taskcluster [actions](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions) documentation.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/actions.json#
+	Actions3 []Actions4
+
+	// Actions provide a generic mechanism to expose additional features of a
+	// provisioner, worker type, or worker to Taskcluster clients.
+	//
+	// An action is comprised of metadata describing the feature it exposes,
+	// together with a webhook for triggering it.
+	//
+	// The Taskcluster tools site, for example, retrieves actions when displaying
+	// provisioners, worker types and workers. It presents the provisioner/worker
+	// type/worker specific actions to the user. When the user triggers an action,
+	// the web client takes the registered webhook, substitutes parameters into the
+	// URL (see `url`), signs the requests with the Taskcluster credentials of the
+	// user operating the web interface, and issues the HTTP request.
+	//
+	// The level to which the action relates (provisioner, worker type, worker) is
+	// called the action context. All actions, regardless of the action contexts,
+	// are registered against the provisioner when calling
+	// `queue.declareProvisioner`.
+	//
+	// The action context is used by the web client to determine where in the web
+	// interface to present the action to the user as follows:
+	//
+	// | `context`   | Tool where action is displayed |
+	// |-------------|--------------------------------|
+	// | provisioner | Provisioner Explorer           |
+	// | worker-type | Workers Explorer               |
+	// | worker      | Worker Explorer                |
+	//
+	// See [actions docs](https://docs.taskcluster.net/reference/platform/taskcluster-queue/docs/actions)
+	// for more information.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/actions.json#/items
+	Actions4 struct {
+
+		// Actions have a "context" that is one of provisioner, worker-type, or worker, indicating
+		// which it applies to. `context` is used by the front-end to know where to display the action.
+		//
+		// | `context`   | Page displayed        |
+		// |-------------|-----------------------|
+		// | provisioner | Provisioner Explorer  |
+		// | worker-type | Workers Explorer      |
+		// | worker      | Worker Explorer       |
+		//
+		// Possible values:
+		//   * "provisioner"
+		//   * "worker-type"
+		//   * "worker"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/context
+		Context string `json:"context"`
+
+		// Description of the provisioner.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/description
+		Description string `json:"description"`
+
+		// Method to indicate the desired action to be performed for a given resource.
+		//
+		// Possible values:
+		//   * "POST"
+		//   * "PUT"
+		//   * "DELETE"
+		//   * "PATCH"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/method
+		Method string `json:"method"`
+
+		// Short names for things like logging/error messages.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/name
+		Name string `json:"name"`
+
+		// Appropriate title for any sort of Modal prompt.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/title
+		Title json.RawMessage `json:"title"`
+
+		// When an action is triggered, a request is made using the `url` and `method`.
+		// Depending on the `context`, the following parameters will be substituted in the url:
+		//
+		// | `context`   | Path parameters                                          |
+		// |-------------|----------------------------------------------------------|
+		// | provisioner | <provisionerId>                                          |
+		// | worker-type | <provisionerId>, <workerType>                            |
+		// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
+		//
+		// _Note: The request needs to be signed with the user's Taskcluster credentials._
+		//
+		// See http://schemas.taskcluster.net/queue/v1/actions.json#/items/properties/url
+		URL string `json:"url"`
+	}
+
+	// Information about an artifact for the given `taskId` and `runId`.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items
+	Artifact struct {
+
+		// Mimetype for the artifact that was created.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/contentType
+		ContentType string `json:"contentType"`
+
+		// Date and time after which the artifact created will be automatically
+		// deleted by the queue.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/expires
+		Expires tcclient.Time `json:"expires"`
+
+		// Name of the artifact that was created, this is useful if you want to
+		// attempt to fetch the artifact.
+		//
+		// Max length: 1024
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/name
+		Name string `json:"name"`
+
+		// This is the `storageType` for the request that was used to create
+		// the artifact.
+		//
+		// Possible values:
+		//   * "blob"
+		//   * "s3"
+		//   * "azure"
+		//   * "reference"
+		//   * "error"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/storageType
+		StorageType string `json:"storageType"`
+	}
+
 	// Request for an Azure Shared Access Signature (SAS) that will allow
 	// you to upload an artifact to an Azure blob storage container managed
 	// by the queue.
@@ -155,26 +455,7 @@ type (
 		// Min length: 1
 		//
 		// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts
-		Parts []struct {
-
-			// The sha256 hash of the part.
-			//
-			// Syntax:     ^[a-fA-F0-9]{64}$
-			// Min length: 64
-			// Max length: 64
-			//
-			// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/sha256
-			Sha256 string `json:"sha256,omitempty"`
-
-			// The number of bytes in this part.  Keep in mind for S3 that
-			// all but the last part must be minimum 5MB and the maximum for
-			// a single part is 5GB.  The overall size may not exceed 5TB
-			//
-			// Mininum:    0
-			//
-			// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/size
-			Size int64 `json:"size,omitempty"`
-		} `json:"parts,omitempty"`
+		Parts []PartsEntry `json:"parts,omitempty"`
 
 		// Artifact storage type, in this case `'blob'`
 		//
@@ -250,88 +531,7 @@ type (
 		// the worker should sleep a tiny bit before polling again.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks
-		Tasks []struct {
-
-			// Temporary credentials granting `task.scopes` and the scope:
-			// `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
-			// the task, upload artifacts and report task resolution.
-			//
-			// The temporary credentials are set to expire after `takenUntil`. They
-			// won't expire exactly at `takenUntil` but shortly after, hence, requests
-			// coming close `takenUntil` won't have problems even if there is a little
-			// clock drift.
-			//
-			// Workers should use these credentials when making requests on behalf of
-			// a task. This includes requests to create artifacts, reclaiming the task
-			// reporting the task `completed`, `failed` or `exception`.
-			//
-			// Note, a new set of temporary credentials is issued when the worker
-			// reclaims the task.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
-			Credentials struct {
-
-				// The `accessToken` for the temporary credentials.
-				//
-				// Min length: 1
-				//
-				// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/accessToken
-				AccessToken string `json:"accessToken"`
-
-				// The `certificate` for the temporary credentials, these are required
-				// for the temporary credentials to work.
-				//
-				// Min length: 1
-				//
-				// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/certificate
-				Certificate string `json:"certificate"`
-
-				// The `clientId` for the temporary credentials.
-				//
-				// Min length: 1
-				//
-				// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/clientId
-				ClientID string `json:"clientId"`
-			} `json:"credentials"`
-
-			// `run-id` assigned to this run of the task
-			//
-			// Mininum:    0
-			// Maximum:    1000
-			//
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/runId
-			RunID int64 `json:"runId"`
-
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/status
-			Status TaskStatusStructure `json:"status"`
-
-			// Time at which the run expires and is resolved as `exception`,
-			// with reason `claim-expired` if the run haven't been reclaimed.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/takenUntil
-			TakenUntil tcclient.Time `json:"takenUntil"`
-
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/task
-			Task TaskDefinitionResponse `json:"task"`
-
-			// Identifier for the worker-group within which this run started.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerGroup
-			WorkerGroup string `json:"workerGroup"`
-
-			// Identifier for the worker executing this run.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerId
-			WorkerID string `json:"workerId"`
-		} `json:"tasks"`
+		Tasks []TasksEntry `json:"tasks"`
 	}
 
 	// Complete an aritifact
@@ -380,6 +580,132 @@ type (
 		//
 		// See http://schemas.taskcluster.net/queue/v1/pending-tasks-response.json#/properties/workerType
 		WorkerType string `json:"workerType"`
+	}
+
+	// Temporary credentials granting `task.scopes` and the scope:
+	// `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+	// the task, upload artifacts and report task resolution.
+	//
+	// The temporary credentials are set to expire after `takenUntil`. They
+	// won't expire exactly at `takenUntil` but shortly after, hence, requests
+	// coming close `takenUntil` won't have problems even if there is a little
+	// clock drift.
+	//
+	// Workers should use these credentials when making requests on behalf of
+	// a task. This includes requests to create artifacts, reclaiming the task
+	// reporting the task `completed`, `failed` or `exception`.
+	//
+	// Note, a new set of temporary credentials is issued when the worker
+	// reclaims the task.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
+	Credentials struct {
+
+		// The `accessToken` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/accessToken
+		AccessToken string `json:"accessToken"`
+
+		// The `certificate` for the temporary credentials, these are required
+		// for the temporary credentials to work.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/certificate
+		Certificate string `json:"certificate"`
+
+		// The `clientId` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials/properties/clientId
+		ClientID string `json:"clientId"`
+	}
+
+	// Temporary credentials granting `task.scopes` and the scope:
+	// `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+	// the task, upload artifacts and report task resolution.
+	//
+	// The temporary credentials are set to expire after `takenUntil`. They
+	// won't expire exactly at `takenUntil` but shortly after, hence, requests
+	// coming close `takenUntil` won't have problems even if there is a little
+	// clock drift.
+	//
+	// Workers should use these credentials when making requests on behalf of
+	// a task. This includes requests to create artifacts, reclaiming the task
+	// reporting the task `completed`, `failed` or `exception`.
+	//
+	// Note, a new set of temporary credentials is issued when the worker
+	// reclaims the task.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials
+	Credentials1 struct {
+
+		// The `accessToken` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/accessToken
+		AccessToken string `json:"accessToken"`
+
+		// The `certificate` for the temporary credentials, these are required
+		// for the temporary credentials to work.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/certificate
+		Certificate string `json:"certificate"`
+
+		// The `clientId` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/clientId
+		ClientID string `json:"clientId"`
+	}
+
+	// Temporary credentials granting `task.scopes` and the scope:
+	// `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+	// the task, upload artifacts and report task resolution.
+	//
+	// The temporary credentials are set to expire after `takenUntil`. They
+	// won't expire exactly at `takenUntil` but shortly after, hence, requests
+	// coming close `takenUntil` won't have problems even if there is a little
+	// clock drift.
+	//
+	// Workers should use these credentials when making requests on behalf of
+	// a task. This includes requests to create artifacts, reclaiming the task
+	// reporting the task `completed`, `failed` or `exception`.
+	//
+	// Note, a new set of temporary credentials is issued when the worker
+	// reclaims the task.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials
+	Credentials2 struct {
+
+		// The `accessToken` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/accessToken
+		AccessToken string `json:"accessToken"`
+
+		// The `certificate` for the temporary credentials, these are required
+		// for the temporary credentials to work.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/certificate
+		Certificate string `json:"certificate"`
+
+		// The `clientId` for the temporary credentials.
+		//
+		// Min length: 1
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/clientId
+		ClientID string `json:"clientId"`
 	}
 
 	// Request the queue to reply `403` (forbidden) with `reason` and `message`
@@ -445,42 +771,7 @@ type (
 		// List of artifacts for given `taskId` and `runId`.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts
-		Artifacts []struct {
-
-			// Mimetype for the artifact that was created.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/contentType
-			ContentType string `json:"contentType"`
-
-			// Date and time after which the artifact created will be automatically
-			// deleted by the queue.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/expires
-			Expires tcclient.Time `json:"expires"`
-
-			// Name of the artifact that was created, this is useful if you want to
-			// attempt to fetch the artifact.
-			//
-			// Max length: 1024
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/name
-			Name string `json:"name"`
-
-			// This is the `storageType` for the request that was used to create
-			// the artifact.
-			//
-			// Possible values:
-			//   * "blob"
-			//   * "s3"
-			//   * "azure"
-			//   * "reference"
-			//   * "error"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-artifacts-response.json#/properties/artifacts/items/properties/storageType
-			StorageType string `json:"storageType"`
-		} `json:"artifacts"`
+		Artifacts []Artifact `json:"artifacts"`
 
 		// Opaque `continuationToken` to be given as query-string option to get the
 		// next set of artifacts.
@@ -520,14 +811,7 @@ type (
 		// List of tasks that have `taskId` in the `task.dependencies` property.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks
-		Tasks []struct {
-
-			// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/status
-			Status TaskStatusStructure `json:"status"`
-
-			// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/task
-			Task TaskDefinitionResponse `json:"task"`
-		} `json:"tasks"`
+		Tasks []TaskDefinitionAndStatus1 `json:"tasks"`
 	}
 
 	// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#
@@ -545,105 +829,7 @@ type (
 		ContinuationToken string `json:"continuationToken,omitempty"`
 
 		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners
-		Provisioners []struct {
-
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions
-			Actions []struct {
-
-				// Actions have a "context" that is one of provisioner, worker-type,
-				// or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-				//
-				// | `context`   | Page displayed        |
-				// |-------------|-----------------------|
-				// | provisioner | Provisioner Explorer  |
-				// | worker-type | Workers Explorer      |
-				// | worker      | Worker Explorer       |
-				//
-				// Possible values:
-				//   * "provisioner"
-				//   * "worker-type"
-				//   * "worker"
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/context
-				Context string `json:"context"`
-
-				// Description of the provisioner.
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/description
-				Description string `json:"description"`
-
-				// Method to indicate the desired action to be performed for a given resource.
-				//
-				// Possible values:
-				//   * "POST"
-				//   * "PUT"
-				//   * "DELETE"
-				//   * "PATCH"
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/method
-				Method string `json:"method"`
-
-				// Short names for things like logging/error messages.
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/name
-				Name string `json:"name"`
-
-				// Appropriate title for any sort of Modal prompt.
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/title
-				Title json.RawMessage `json:"title"`
-
-				// When an action is triggered, a request is made using the `url` and `method`.
-				// Depending on the `context`, the following parameters will be substituted in the url:
-				//
-				// | `context`   | Path parameters                                          |
-				// |-------------|----------------------------------------------------------|
-				// | provisioner | <provisionerId>                                          |
-				// | worker-type | <provisionerId>, <workerType>                            |
-				// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
-				//
-				// _Note: The request needs to be signed with the user's Taskcluster credentials._
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions/items/properties/url
-				URL string `json:"url"`
-			} `json:"actions"`
-
-			// Description of the provisioner.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/description
-			Description string `json:"description"`
-
-			// Date and time after which the provisioner created will be automatically
-			// deleted by the queue.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/expires
-			Expires tcclient.Time `json:"expires"`
-
-			// Date and time where the provisioner was last seen active
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/lastDateActive
-			LastDateActive tcclient.Time `json:"lastDateActive"`
-
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/provisionerId
-			ProvisionerID string `json:"provisionerId"`
-
-			// This is the stability of the provisioner. Accepted values:
-			//  * `experimental`
-			//  * `stable`
-			//  * `deprecated`
-			//
-			// Possible values:
-			//   * "experimental"
-			//   * "stable"
-			//   * "deprecated"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/stability
-			Stability string `json:"stability"`
-		} `json:"provisioners"`
+		Provisioners []ProvisionerInformation `json:"provisioners"`
 	}
 
 	// Response from a `listTaskGroup` request.
@@ -672,14 +858,7 @@ type (
 		// List of tasks in this task-group.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks
-		Tasks []struct {
-
-			// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/status
-			Status TaskStatusStructure `json:"status"`
-
-			// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/task
-			Task TaskDefinitionResponse `json:"task"`
-		} `json:"tasks"`
+		Tasks []TaskDefinitionAndStatus `json:"tasks"`
 	}
 
 	// Response from a `listWorkerTypes` request.
@@ -701,53 +880,7 @@ type (
 		// List of worker-types in this provisioner.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes
-		WorkerTypes []struct {
-
-			// Description of the worker-type.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/description
-			Description string `json:"description,omitempty"`
-
-			// Date and time after which the worker-type will be automatically
-			// deleted by the queue.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/expires
-			Expires tcclient.Time `json:"expires,omitempty"`
-
-			// Date and time where the worker-type was last seen active
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/lastDateActive
-			LastDateActive tcclient.Time `json:"lastDateActive,omitempty"`
-
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/provisionerId
-			ProvisionerID string `json:"provisionerId,omitempty"`
-
-			// This is the stability of the worker-type. Accepted values:
-			//  * `experimental`
-			//  * `stable`
-			//  * `deprecated`
-			//
-			// Possible values:
-			//   * "experimental"
-			//   * "stable"
-			//   * "deprecated"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/stability
-			Stability string `json:"stability,omitempty"`
-
-			// WorkerType name.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/workerType
-			WorkerType string `json:"workerType,omitempty"`
-		} `json:"workerTypes"`
+		WorkerTypes []WorkerTypesEntry `json:"workerTypes"`
 	}
 
 	// Response from a `listWorkers` request.
@@ -769,62 +902,132 @@ type (
 		// List of workers in this worker-type.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers
-		Workers []struct {
+		Workers []WorkersEntry `json:"workers"`
+	}
 
-			// Date of the first time this worker claimed a task.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/firstClaim
-			FirstClaim tcclient.Time `json:"firstClaim"`
+	// Required task metadata
+	//
+	// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
+	MetaData struct {
 
-			// The most recent claimed task
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
-			LatestTask struct {
+		// Human readable description of the task, please **explain** what the
+		// task does. A few lines of documentation is not going to hurt you.
+		//
+		// Max length: 32768
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
+		Description string `json:"description"`
 
-				// Id of this task run, `run-id`s always starts from `0`
-				//
-				// Mininum:    0
-				// Maximum:    1000
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/runId
-				RunID int64 `json:"runId"`
+		// Human readable name of task, used to very briefly given an idea about
+		// what the task does.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
+		Name string `json:"name"`
 
-				// Unique task identifier, this is UUID encoded as
-				// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-				// stripped of `=` padding.
-				//
-				// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-				//
-				// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/taskId
-				TaskID string `json:"taskId"`
-			} `json:"latestTask,omitempty"`
+		// E-mail of person who caused this task, e.g. the person who did
+		// `hg push`. The person we should contact to ask why this task is here.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
+		Owner string `json:"owner"`
 
-			// Quarantining a worker allows the machine to remain alive but not accept jobs.
-			// Once the quarantineUntil time has elapsed, the worker resumes accepting jobs.
-			// Note that a quarantine can be lifted by setting `quarantineUntil` to the present time (or
-			// somewhere in the past).
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/quarantineUntil
-			QuarantineUntil tcclient.Time `json:"quarantineUntil,omitempty"`
+		// Link to source of this task, should specify a file, revision and
+		// repository. This should be place someone can go an do a git/hg blame
+		// to who came up with recipe for this task.
+		//
+		// Syntax:     ^https?://
+		// Max length: 4096
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
+		Source string `json:"source"`
+	}
 
-			// Identifier for the worker group containing this worker.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerGroup
-			WorkerGroup string `json:"workerGroup"`
+	// Required task metadata
+	//
+	// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata
+	MetaData1 struct {
 
-			// Identifier for this worker (unique within this worker group).
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerId
-			WorkerID string `json:"workerId"`
-		} `json:"workers"`
+		// Human readable description of the task, please **explain** what the
+		// task does. A few lines of documentation is not going to hurt you.
+		//
+		// Max length: 32768
+		//
+		// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/description
+		Description string `json:"description"`
+
+		// Human readable name of task, used to very briefly given an idea about
+		// what the task does.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/name
+		Name string `json:"name"`
+
+		// E-mail of person who caused this task, e.g. the person who did
+		// `hg push`. The person we should contact to ask why this task is here.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/owner
+		Owner string `json:"owner"`
+
+		// Link to source of this task, should specify a file, revision and
+		// repository. This should be place someone can go an do a git/hg blame
+		// to who came up with recipe for this task.
+		//
+		// Syntax:     ^https?://
+		// Max length: 4096
+		//
+		// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/source
+		Source string `json:"source"`
+	}
+
+	// The most recent claimed task
+	//
+	// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
+	MostRecentTask struct {
+
+		// Id of this task run, `run-id`s always starts from `0`
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/runId
+		RunID int64 `json:"runId"`
+
+		// Unique task identifier, this is UUID encoded as
+		// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+		// stripped of `=` padding.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask/properties/taskId
+		TaskID string `json:"taskId"`
+	}
+
+	// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items
+	PartsEntry struct {
+
+		// The sha256 hash of the part.
+		//
+		// Syntax:     ^[a-fA-F0-9]{64}$
+		// Min length: 64
+		// Max length: 64
+		//
+		// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/sha256
+		Sha256 string `json:"sha256,omitempty"`
+
+		// The number of bytes in this part.  Keep in mind for S3 that
+		// all but the last part must be minimum 5MB and the maximum for
+		// a single part is 5GB.  The overall size may not exceed 5TB
+		//
+		// Mininum:    0
+		//
+		// See http://schemas.taskcluster.net/queue/v1/post-artifact-request.json#/oneOf[0]/properties/parts/items/properties/size
+		Size int64 `json:"size,omitempty"`
 	}
 
 	// Response to request for poll task urls.
@@ -843,41 +1046,7 @@ type (
 		// have higher priority.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues
-		Queues []struct {
-
-			// Signed URL to delete messages that have been received using the
-			// `signedPollUrl`. You **must** do this to avoid receiving the same
-			// message again.
-			// To use this URL you must substitute `{{messageId}}` and
-			// `{{popReceipt}}` with `MessageId` and `PopReceipt` from the XML
-			// response the `signedPollUrl` gave you. It is important that you
-			// `encodeURIComponent` both `MessageId` and `PopReceipt` prior to
-			// substitution, otherwise you will experience intermittent failures!
-			// Note this URL only works with `DELETE` request.
-			//
-			// Syntax:     ^https://
-			//
-			// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedDeleteUrl
-			SignedDeleteURL string `json:"signedDeleteUrl"`
-
-			// Signed URL to get message from the Azure Queue Storage queue,
-			// that holds messages for the given `provisionerId` and `workerType`.
-			// Note that this URL returns XML, see documentation for the Azure
-			// Queue Storage
-			// [REST API](http://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
-			// for details.
-			// When you have a message you can use `claimTask` to claim the task.
-			// You will need to parse the XML response and base64 decode and
-			// JSON parse the `MessageText`.
-			// After you have called `claimTask` you **must** us the
-			// `signedDeleteUrl` to delete the message.
-			// **Remark**, you are allowed to append `&numofmessages=N`,
-			// where N < 32, to the URLs if you wish to obtain more than one
-			// message at the time.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedPollUrl
-			SignedPollURL string `json:"signedPollUrl"`
-		} `json:"queues"`
+		Queues []SignedURLsForAQueue `json:"queues"`
 	}
 
 	// Request a authorization to put and artifact or posting of a URL as an artifact. Note that the `storageType` property is referenced in the response as well.
@@ -905,71 +1074,56 @@ type (
 	// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#
 	PostArtifactResponse json.RawMessage
 
+	// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items
+	ProvisionerInformation struct {
+
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/actions
+		Actions Actions3 `json:"actions"`
+
+		// Description of the provisioner.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/description
+		Description string `json:"description"`
+
+		// Date and time after which the provisioner created will be automatically
+		// deleted by the queue.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/expires
+		Expires tcclient.Time `json:"expires"`
+
+		// Date and time where the provisioner was last seen active
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/lastDateActive
+		LastDateActive tcclient.Time `json:"lastDateActive"`
+
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/provisionerId
+		ProvisionerID string `json:"provisionerId"`
+
+		// This is the stability of the provisioner. Accepted values:
+		//  * `experimental`
+		//  * `stable`
+		//  * `deprecated`
+		//
+		// Possible values:
+		//   * "experimental"
+		//   * "stable"
+		//   * "deprecated"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-provisioners-response.json#/properties/provisioners/items/properties/stability
+		Stability string `json:"stability"`
+	}
+
 	// Request to update a provisioner.
 	//
 	// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#
 	ProvisionerRequest struct {
 
 		// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions
-		Actions []struct {
-
-			// Actions have a "context" that is one of provisioner, worker-type,
-			// or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-			//
-			// | `context`   | Page displayed        |
-			// |-------------|-----------------------|
-			// | provisioner | Provisioner Explorer  |
-			// | worker-type | Workers Explorer      |
-			// | worker      | Worker Explorer       |
-			//
-			// Possible values:
-			//   * "provisioner"
-			//   * "worker-type"
-			//   * "worker"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/context
-			Context string `json:"context"`
-
-			// Description of the provisioner.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/description
-			Description string `json:"description"`
-
-			// Method to indicate the desired action to be performed for a given resource.
-			//
-			// Possible values:
-			//   * "POST"
-			//   * "PUT"
-			//   * "DELETE"
-			//   * "PATCH"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/method
-			Method string `json:"method"`
-
-			// Short names for things like logging/error messages.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/name
-			Name string `json:"name"`
-
-			// Appropriate title for any sort of Modal prompt.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/title
-			Title json.RawMessage `json:"title"`
-
-			// When an action is triggered, a request is made using the `url` and `method`.
-			// Depending on the `context`, the following parameters will be substituted in the url:
-			//
-			// | `context`   | Path parameters                                          |
-			// |-------------|----------------------------------------------------------|
-			// | provisioner | <provisionerId>                                          |
-			// | worker-type | <provisionerId>, <workerType>                            |
-			// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
-			//
-			// _Note: The request needs to be signed with the user's Taskcluster credentials._
-			//
-			// See http://schemas.taskcluster.net/queue/v1/update-provisioner-request.json#/properties/actions/items/properties/url
-			URL string `json:"url"`
-		} `json:"actions,omitempty"`
+		Actions Actions3 `json:"actions,omitempty"`
 
 		// Description of the provisioner.
 		//
@@ -1002,65 +1156,7 @@ type (
 	ProvisionerResponse struct {
 
 		// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions
-		Actions []struct {
-
-			// Actions have a "context" that is one of provisioner, worker-type,
-			// or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-			//
-			// | `context`   | Page displayed        |
-			// |-------------|-----------------------|
-			// | provisioner | Provisioner Explorer  |
-			// | worker-type | Workers Explorer      |
-			// | worker      | Worker Explorer       |
-			//
-			// Possible values:
-			//   * "provisioner"
-			//   * "worker-type"
-			//   * "worker"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/context
-			Context string `json:"context"`
-
-			// Description of the provisioner.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/description
-			Description string `json:"description"`
-
-			// Method to indicate the desired action to be performed for a given resource.
-			//
-			// Possible values:
-			//   * "POST"
-			//   * "PUT"
-			//   * "DELETE"
-			//   * "PATCH"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/method
-			Method string `json:"method"`
-
-			// Short names for things like logging/error messages.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/name
-			Name string `json:"name"`
-
-			// Appropriate title for any sort of Modal prompt.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/title
-			Title json.RawMessage `json:"title"`
-
-			// When an action is triggered, a request is made using the `url` and `method`.
-			// Depending on the `context`, the following parameters will be substituted in the url:
-			//
-			// | `context`   | Path parameters                                          |
-			// |-------------|----------------------------------------------------------|
-			// | provisioner | <provisionerId>                                          |
-			// | worker-type | <provisionerId>, <workerType>                            |
-			// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
-			//
-			// _Note: The request needs to be signed with the user's Taskcluster credentials._
-			//
-			// See http://schemas.taskcluster.net/queue/v1/provisioner-response.json#/properties/actions/items/properties/url
-			URL string `json:"url"`
-		} `json:"actions"`
+		Actions Actions3 `json:"actions"`
 
 		// Description of the provisioner.
 		//
@@ -1113,6 +1209,27 @@ type (
 		//
 		// See http://schemas.taskcluster.net/queue/v1/quarantine-worker-request.json#/properties/quarantineUntil
 		QuarantineUntil tcclient.Time `json:"quarantineUntil,omitempty"`
+	}
+
+	// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items
+	RecentTasksEntry struct {
+
+		// Id of this task run, `run-id`s always starts from `0`
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/runId
+		RunID int64 `json:"runId,omitempty"`
+
+		// Unique task identifier, this is UUID encoded as
+		// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
+		// stripped of `=` padding.
+		//
+		// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
+		//
+		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/taskId
+		TaskID string `json:"taskId,omitempty"`
 	}
 
 	// Request the queue to redirect to a URL for a given artifact.
@@ -1171,6 +1288,151 @@ type (
 		//
 		// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[3]/properties/storageType
 		StorageType string `json:"storageType"`
+	}
+
+	// Defined properties:
+	//
+	//  struct {
+	//
+	//  	// Headers of request
+	//  	//
+	//  	// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/headers
+	//  	Headers map[string]string `json:"headers,omitempty"`
+	//
+	//  	// HTTP 1.1 method of request
+	//  	//
+	//  	// Possible values:
+	//  	//   * "GET"
+	//  	//   * "POST"
+	//  	//   * "PUT"
+	//  	//   * "DELETE"
+	//  	//   * "OPTIONS"
+	//  	//   * "HEAD"
+	//  	//   * "PATCH"
+	//  	//
+	//  	// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/method
+	//  	Method string `json:"method,omitempty"`
+	//
+	//  	// URL of request
+	//  	//
+	//  	// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items/properties/url
+	//  	URL string `json:"url,omitempty"`
+	//  }
+	//
+	// Additional properties allowed
+	//
+	// See http://schemas.taskcluster.net/queue/v1/post-artifact-response.json#/oneOf[0]/properties/requests/items
+	RequestsEntry json.RawMessage
+
+	// JSON object with information about a run
+	//
+	// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+	RunInformation struct {
+
+		// Reason for the creation of this run,
+		// **more reasons may be added in the future**.
+		//
+		// Possible values:
+		//   * "scheduled"
+		//   * "retry"
+		//   * "task-retry"
+		//   * "rerun"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+		ReasonCreated string `json:"reasonCreated"`
+
+		// Reason that run was resolved, this is mainly
+		// useful for runs resolved as `exception`.
+		// Note, **more reasons may be added in the future**, also this
+		// property is only available after the run is resolved. Some of these
+		// reasons, notably `intermittent-task`, `worker-shutdown`, and
+		// `claim-expired`, will trigger an automatic retry of the task.
+		//
+		// Possible values:
+		//   * "completed"
+		//   * "failed"
+		//   * "deadline-exceeded"
+		//   * "canceled"
+		//   * "superseded"
+		//   * "claim-expired"
+		//   * "worker-shutdown"
+		//   * "malformed-payload"
+		//   * "resource-unavailable"
+		//   * "internal-error"
+		//   * "intermittent-task"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+		ReasonResolved string `json:"reasonResolved,omitempty"`
+
+		// Date-time at which this run was resolved, ie. when the run changed
+		// state from `running` to either `completed`, `failed` or `exception`.
+		// This property is only present after the run as been resolved.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+		Resolved tcclient.Time `json:"resolved,omitempty"`
+
+		// Id of this task run, `run-id`s always starts from `0`
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+		RunID int64 `json:"runId"`
+
+		// Date-time at which this run was scheduled, ie. when the run was
+		// created in state `pending`.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+		Scheduled tcclient.Time `json:"scheduled"`
+
+		// Date-time at which this run was claimed, ie. when the run changed
+		// state from `pending` to `running`. This property is only present
+		// after the run has been claimed.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+		Started tcclient.Time `json:"started,omitempty"`
+
+		// State of this run
+		//
+		// Possible values:
+		//   * "pending"
+		//   * "running"
+		//   * "completed"
+		//   * "failed"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+		State string `json:"state"`
+
+		// Time at which the run expires and is resolved as `failed`, if the
+		// run isn't reclaimed. Note, only present after the run has been
+		// claimed.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+		TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
+
+		// Identifier for group that worker who executes this run is a part of,
+		// this identifier is mainly used for efficient routing.
+		// Note, this property is only present after the run is claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+		WorkerGroup string `json:"workerGroup,omitempty"`
+
+		// Identifier for worker evaluating this run within given
+		// `workerGroup`. Note, this property is only available after the run
+		// has been claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+		WorkerID string `json:"workerId,omitempty"`
 	}
 
 	// Request for a signed PUT URL that will allow you to upload an artifact
@@ -1242,6 +1504,49 @@ type (
 		StorageType string `json:"storageType"`
 	}
 
+	// Object holding two signed URLs for an azure queue, one for fetching
+	// messages, and another for deleting messages. Remember to `claimTask`
+	// before deleting the message, and delete message even if the `claimTask`
+	// operation fails with a 400 status code. Don't delete it on other status
+	// codes!
+	//
+	// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items
+	SignedURLsForAQueue struct {
+
+		// Signed URL to delete messages that have been received using the
+		// `signedPollUrl`. You **must** do this to avoid receiving the same
+		// message again.
+		// To use this URL you must substitute `{{messageId}}` and
+		// `{{popReceipt}}` with `MessageId` and `PopReceipt` from the XML
+		// response the `signedPollUrl` gave you. It is important that you
+		// `encodeURIComponent` both `MessageId` and `PopReceipt` prior to
+		// substitution, otherwise you will experience intermittent failures!
+		// Note this URL only works with `DELETE` request.
+		//
+		// Syntax:     ^https://
+		//
+		// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedDeleteUrl
+		SignedDeleteURL string `json:"signedDeleteUrl"`
+
+		// Signed URL to get message from the Azure Queue Storage queue,
+		// that holds messages for the given `provisionerId` and `workerType`.
+		// Note that this URL returns XML, see documentation for the Azure
+		// Queue Storage
+		// [REST API](http://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
+		// for details.
+		// When you have a message you can use `claimTask` to claim the task.
+		// You will need to parse the XML response and base64 decode and
+		// JSON parse the `MessageText`.
+		// After you have called `claimTask` you **must** us the
+		// `signedDeleteUrl` to delete the message.
+		// **Remark**, you are allowed to append `&numofmessages=N`,
+		// where N < 32, to the URLs if you wish to obtain more than one
+		// message at the time.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/poll-task-urls-response.json#/properties/queues/items/properties/signedPollUrl
+		SignedPollURL string `json:"signedPollUrl"`
+	}
+
 	// Request to claim (or reclaim) a task
 	//
 	// See http://schemas.taskcluster.net/queue/v1/task-claim-request.json#
@@ -1288,30 +1593,7 @@ type (
 		// reclaims the task.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials
-		Credentials struct {
-
-			// The `accessToken` for the temporary credentials.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/accessToken
-			AccessToken string `json:"accessToken"`
-
-			// The `certificate` for the temporary credentials, these are required
-			// for the temporary credentials to work.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/certificate
-			Certificate string `json:"certificate"`
-
-			// The `clientId` for the temporary credentials.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/credentials/properties/clientId
-			ClientID string `json:"clientId"`
-		} `json:"credentials"`
+		Credentials Credentials1 `json:"credentials"`
 
 		// `run-id` assigned to this run of the task
 		//
@@ -1350,6 +1632,30 @@ type (
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task-claim-response.json#/properties/workerId
 		WorkerID string `json:"workerId"`
+	}
+
+	// Task Definition and task status structure.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items
+	TaskDefinitionAndStatus struct {
+
+		// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/status
+		Status TaskStatusStructure `json:"status"`
+
+		// See http://schemas.taskcluster.net/queue/v1/list-task-group-response.json#/properties/tasks/items/properties/task
+		Task TaskDefinitionResponse `json:"task"`
+	}
+
+	// Task Definition and task status structure.
+	//
+	// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items
+	TaskDefinitionAndStatus1 struct {
+
+		// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/status
+		Status TaskStatusStructure `json:"status"`
+
+		// See http://schemas.taskcluster.net/queue/v1/list-dependent-tasks-response.json#/properties/tasks/items/properties/task
+		Task TaskDefinitionResponse `json:"task"`
 	}
 
 	// Definition of a task that can be scheduled
@@ -1406,42 +1712,7 @@ type (
 		// Required task metadata
 		//
 		// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata
-		Metadata struct {
-
-			// Human readable description of the task, please **explain** what the
-			// task does. A few lines of documentation is not going to hurt you.
-			//
-			// Max length: 32768
-			//
-			// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/description
-			Description string `json:"description"`
-
-			// Human readable name of task, used to very briefly given an idea about
-			// what the task does.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/name
-			Name string `json:"name"`
-
-			// E-mail of person who caused this task, e.g. the person who did
-			// `hg push`. The person we should contact to ask why this task is here.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/owner
-			Owner string `json:"owner"`
-
-			// Link to source of this task, should specify a file, revision and
-			// repository. This should be place someone can go an do a git/hg blame
-			// to who came up with recipe for this task.
-			//
-			// Syntax:     ^https?://
-			// Max length: 4096
-			//
-			// See http://schemas.taskcluster.net/queue/v1/create-task-request.json#/properties/metadata/properties/source
-			Source string `json:"source"`
-		} `json:"metadata"`
+		Metadata MetaData1 `json:"metadata"`
 
 		// Task-specific payload following worker-specific format. For example the
 		// `docker-worker` requires keys like: `image`, `commands` and
@@ -1625,42 +1896,7 @@ type (
 		// Required task metadata
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata
-		Metadata struct {
-
-			// Human readable description of the task, please **explain** what the
-			// task does. A few lines of documentation is not going to hurt you.
-			//
-			// Max length: 32768
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/description
-			Description string `json:"description"`
-
-			// Human readable name of task, used to very briefly given an idea about
-			// what the task does.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/name
-			Name string `json:"name"`
-
-			// E-mail of person who caused this task, e.g. the person who did
-			// `hg push`. The person we should contact to ask why this task is here.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/owner
-			Owner string `json:"owner"`
-
-			// Link to source of this task, should specify a file, revision and
-			// repository. This should be place someone can go an do a git/hg blame
-			// to who came up with recipe for this task.
-			//
-			// Syntax:     ^https?://
-			// Max length: 4096
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task.json#/properties/metadata/properties/source
-			Source string `json:"source"`
-		} `json:"metadata"`
+		Metadata MetaData `json:"metadata"`
 
 		// Task-specific payload following worker-specific format. For example the
 		// `docker-worker` requires keys like: `image`, `commands` and
@@ -1850,30 +2086,7 @@ type (
 		// reclaims the task.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials
-		Credentials struct {
-
-			// The `accessToken` for the temporary credentials.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/accessToken
-			AccessToken string `json:"accessToken"`
-
-			// The `certificate` for the temporary credentials, these are required
-			// for the temporary credentials to work.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/certificate
-			Certificate string `json:"certificate"`
-
-			// The `clientId` for the temporary credentials.
-			//
-			// Min length: 1
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-reclaim-response.json#/properties/credentials/properties/clientId
-			ClientID string `json:"clientId"`
-		} `json:"credentials"`
+		Credentials Credentials2 `json:"credentials"`
 
 		// `run-id` assigned to this run of the task
 		//
@@ -1960,113 +2173,7 @@ type (
 		// List of runs, ordered so that index `i` has `runId == i`
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs
-		Runs []struct {
-
-			// Reason for the creation of this run,
-			// **more reasons may be added in the future**.
-			//
-			// Possible values:
-			//   * "scheduled"
-			//   * "retry"
-			//   * "task-retry"
-			//   * "rerun"
-			//   * "exception"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
-			ReasonCreated string `json:"reasonCreated"`
-
-			// Reason that run was resolved, this is mainly
-			// useful for runs resolved as `exception`.
-			// Note, **more reasons may be added in the future**, also this
-			// property is only available after the run is resolved. Some of these
-			// reasons, notably `intermittent-task`, `worker-shutdown`, and
-			// `claim-expired`, will trigger an automatic retry of the task.
-			//
-			// Possible values:
-			//   * "completed"
-			//   * "failed"
-			//   * "deadline-exceeded"
-			//   * "canceled"
-			//   * "superseded"
-			//   * "claim-expired"
-			//   * "worker-shutdown"
-			//   * "malformed-payload"
-			//   * "resource-unavailable"
-			//   * "internal-error"
-			//   * "intermittent-task"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
-			ReasonResolved string `json:"reasonResolved,omitempty"`
-
-			// Date-time at which this run was resolved, ie. when the run changed
-			// state from `running` to either `completed`, `failed` or `exception`.
-			// This property is only present after the run as been resolved.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
-			Resolved tcclient.Time `json:"resolved,omitempty"`
-
-			// Id of this task run, `run-id`s always starts from `0`
-			//
-			// Mininum:    0
-			// Maximum:    1000
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
-			RunID int64 `json:"runId"`
-
-			// Date-time at which this run was scheduled, ie. when the run was
-			// created in state `pending`.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
-			Scheduled tcclient.Time `json:"scheduled"`
-
-			// Date-time at which this run was claimed, ie. when the run changed
-			// state from `pending` to `running`. This property is only present
-			// after the run has been claimed.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
-			Started tcclient.Time `json:"started,omitempty"`
-
-			// State of this run
-			//
-			// Possible values:
-			//   * "pending"
-			//   * "running"
-			//   * "completed"
-			//   * "failed"
-			//   * "exception"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
-			State string `json:"state"`
-
-			// Time at which the run expires and is resolved as `failed`, if the
-			// run isn't reclaimed. Note, only present after the run has been
-			// claimed.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
-			TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
-
-			// Identifier for group that worker who executes this run is a part of,
-			// this identifier is mainly used for efficient routing.
-			// Note, this property is only present after the run is claimed.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
-			WorkerGroup string `json:"workerGroup,omitempty"`
-
-			// Identifier for worker evaluating this run within given
-			// `workerGroup`. Note, this property is only available after the run
-			// has been claimed.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
-			WorkerID string `json:"workerId,omitempty"`
-		} `json:"runs"`
+		Runs []RunInformation `json:"runs"`
 
 		// Identifier for the scheduler that _defined_ this task.
 		//
@@ -2119,6 +2226,67 @@ type (
 		WorkerType string `json:"workerType"`
 	}
 
+	// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items
+	TasksEntry struct {
+
+		// Temporary credentials granting `task.scopes` and the scope:
+		// `queue:claim-task:<taskId>/<runId>` which allows the worker to reclaim
+		// the task, upload artifacts and report task resolution.
+		//
+		// The temporary credentials are set to expire after `takenUntil`. They
+		// won't expire exactly at `takenUntil` but shortly after, hence, requests
+		// coming close `takenUntil` won't have problems even if there is a little
+		// clock drift.
+		//
+		// Workers should use these credentials when making requests on behalf of
+		// a task. This includes requests to create artifacts, reclaiming the task
+		// reporting the task `completed`, `failed` or `exception`.
+		//
+		// Note, a new set of temporary credentials is issued when the worker
+		// reclaims the task.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/credentials
+		Credentials Credentials `json:"credentials"`
+
+		// `run-id` assigned to this run of the task
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/runId
+		RunID int64 `json:"runId"`
+
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/status
+		Status TaskStatusStructure `json:"status"`
+
+		// Time at which the run expires and is resolved as `exception`,
+		// with reason `claim-expired` if the run haven't been reclaimed.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/takenUntil
+		TakenUntil tcclient.Time `json:"takenUntil"`
+
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/task
+		Task TaskDefinitionResponse `json:"task"`
+
+		// Identifier for the worker-group within which this run started.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerGroup
+		WorkerGroup string `json:"workerGroup"`
+
+		// Identifier for the worker executing this run.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/claim-work-response.json#/properties/tasks/items/properties/workerId
+		WorkerID string `json:"workerId"`
+	}
+
 	// Request to update a worker.
 	//
 	// See http://schemas.taskcluster.net/queue/v1/update-worker-request.json#
@@ -2137,63 +2305,7 @@ type (
 	WorkerResponse struct {
 
 		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions
-		Actions []struct {
-
-			// Actions have a "context" that is one of provisioner, worker-type,
-			// or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-			//
-			// | `context`   | Page displayed        |
-			// |-------------|-----------------------|
-			// | provisioner | Provisioner Explorer  |
-			// | worker-type | Workers Explorer      |
-			// | worker      | Worker Explorer       |
-			//
-			// Possible values:
-			//   * "worker"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/context
-			Context string `json:"context"`
-
-			// Description of the provisioner.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/description
-			Description string `json:"description"`
-
-			// Method to indicate the desired action to be performed for a given resource.
-			//
-			// Possible values:
-			//   * "POST"
-			//   * "PUT"
-			//   * "DELETE"
-			//   * "PATCH"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/method
-			Method string `json:"method"`
-
-			// Short names for things like logging/error messages.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/name
-			Name string `json:"name"`
-
-			// Appropriate title for any sort of Modal prompt.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/title
-			Title json.RawMessage `json:"title"`
-
-			// When an action is triggered, a request is made using the `url` and `method`.
-			// Depending on the `context`, the following parameters will be substituted in the url:
-			//
-			// | `context`   | Path parameters                                          |
-			// |-------------|----------------------------------------------------------|
-			// | provisioner | <provisionerId>                                          |
-			// | worker-type | <provisionerId>, <workerType>                            |
-			// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
-			//
-			// _Note: The request needs to be signed with the user's Taskcluster credentials._
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/actions/items/properties/url
-			URL string `json:"url"`
-		} `json:"actions"`
+		Actions []Actions2 `json:"actions"`
 
 		// Date and time after which the worker will be automatically
 		// deleted by the queue.
@@ -2224,25 +2336,7 @@ type (
 		// List of 20 most recent tasks claimed by the worker.
 		//
 		// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks
-		RecentTasks []struct {
-
-			// Id of this task run, `run-id`s always starts from `0`
-			//
-			// Mininum:    0
-			// Maximum:    1000
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/runId
-			RunID int64 `json:"runId,omitempty"`
-
-			// Unique task identifier, this is UUID encoded as
-			// [URL-safe base64](http://tools.ietf.org/html/rfc4648#section-5) and
-			// stripped of `=` padding.
-			//
-			// Syntax:     ^[A-Za-z0-9_-]{8}[Q-T][A-Za-z0-9_-][CGKOSWaeimquy26-][A-Za-z0-9_-]{10}[AQgw]$
-			//
-			// See http://schemas.taskcluster.net/queue/v1/worker-response.json#/properties/recentTasks/items/properties/taskId
-			TaskID string `json:"taskId,omitempty"`
-		} `json:"recentTasks"`
+		RecentTasks []RecentTasksEntry `json:"recentTasks"`
 
 		// Identifier for group that worker who executes this run is a part of,
 		// this identifier is mainly used for efficient routing.
@@ -2310,63 +2404,7 @@ type (
 	WorkerTypeResponse struct {
 
 		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions
-		Actions []struct {
-
-			// Actions have a "context" that is one of provisioner, worker-type,
-			// or worker, indicating which it applies to. `context` is used by the front-end to know where to display the action.
-			//
-			// | `context`   | Page displayed        |
-			// |-------------|-----------------------|
-			// | provisioner | Provisioner Explorer  |
-			// | worker-type | Workers Explorer      |
-			// | worker      | Worker Explorer       |
-			//
-			// Possible values:
-			//   * "worker-type"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/context
-			Context string `json:"context"`
-
-			// Description of the provisioner.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/description
-			Description string `json:"description"`
-
-			// Method to indicate the desired action to be performed for a given resource.
-			//
-			// Possible values:
-			//   * "POST"
-			//   * "PUT"
-			//   * "DELETE"
-			//   * "PATCH"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/method
-			Method string `json:"method"`
-
-			// Short names for things like logging/error messages.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/name
-			Name string `json:"name"`
-
-			// Appropriate title for any sort of Modal prompt.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/title
-			Title json.RawMessage `json:"title"`
-
-			// When an action is triggered, a request is made using the `url` and `method`.
-			// Depending on the `context`, the following parameters will be substituted in the url:
-			//
-			// | `context`   | Path parameters                                          |
-			// |-------------|----------------------------------------------------------|
-			// | provisioner | <provisionerId>                                          |
-			// | worker-type | <provisionerId>, <workerType>                            |
-			// | worker      | <provisionerId>, <workerType>, <workerGroup>, <workerId> |
-			//
-			// _Note: The request needs to be signed with the user's Taskcluster credentials._
-			//
-			// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/actions/items/properties/url
-			URL string `json:"url"`
-		} `json:"actions"`
+		Actions []Actions1 `json:"actions"`
 
 		// Description of the worker-type.
 		//
@@ -2415,6 +2453,95 @@ type (
 		// See http://schemas.taskcluster.net/queue/v1/workertype-response.json#/properties/workerType
 		WorkerType string `json:"workerType"`
 	}
+
+	// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items
+	WorkerTypesEntry struct {
+
+		// Description of the worker-type.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/description
+		Description string `json:"description,omitempty"`
+
+		// Date and time after which the worker-type will be automatically
+		// deleted by the queue.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/expires
+		Expires tcclient.Time `json:"expires,omitempty"`
+
+		// Date and time where the worker-type was last seen active
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/lastDateActive
+		LastDateActive tcclient.Time `json:"lastDateActive,omitempty"`
+
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/provisionerId
+		ProvisionerID string `json:"provisionerId,omitempty"`
+
+		// This is the stability of the worker-type. Accepted values:
+		//  * `experimental`
+		//  * `stable`
+		//  * `deprecated`
+		//
+		// Possible values:
+		//   * "experimental"
+		//   * "stable"
+		//   * "deprecated"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/stability
+		Stability string `json:"stability,omitempty"`
+
+		// WorkerType name.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workertypes-response.json#/properties/workerTypes/items/properties/workerType
+		WorkerType string `json:"workerType,omitempty"`
+	}
+
+	// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items
+	WorkersEntry struct {
+
+		// Date of the first time this worker claimed a task.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/firstClaim
+		FirstClaim tcclient.Time `json:"firstClaim"`
+
+		// The most recent claimed task
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/latestTask
+		LatestTask MostRecentTask `json:"latestTask,omitempty"`
+
+		// Quarantining a worker allows the machine to remain alive but not accept jobs.
+		// Once the quarantineUntil time has elapsed, the worker resumes accepting jobs.
+		// Note that a quarantine can be lifted by setting `quarantineUntil` to the present time (or
+		// somewhere in the past).
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/quarantineUntil
+		QuarantineUntil tcclient.Time `json:"quarantineUntil,omitempty"`
+
+		// Identifier for the worker group containing this worker.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerGroup
+		WorkerGroup string `json:"workerGroup"`
+
+		// Identifier for this worker (unique within this worker group).
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/list-workers-response.json#/properties/workers/items/properties/workerId
+		WorkerID string `json:"workerId"`
+	}
 )
 
 // MarshalJSON calls json.RawMessage method of the same name. Required since
@@ -2460,6 +2587,22 @@ func (this *PostArtifactResponse) MarshalJSON() ([]byte, error) {
 func (this *PostArtifactResponse) UnmarshalJSON(data []byte) error {
 	if this == nil {
 		return errors.New("PostArtifactResponse: UnmarshalJSON on nil pointer")
+	}
+	*this = append((*this)[0:0], data...)
+	return nil
+}
+
+// MarshalJSON calls json.RawMessage method of the same name. Required since
+// RequestsEntry is of type json.RawMessage...
+func (this *RequestsEntry) MarshalJSON() ([]byte, error) {
+	x := json.RawMessage(*this)
+	return (&x).MarshalJSON()
+}
+
+// UnmarshalJSON is a copy of the json.RawMessage implementation.
+func (this *RequestsEntry) UnmarshalJSON(data []byte) error {
+	if this == nil {
+		return errors.New("RequestsEntry: UnmarshalJSON on nil pointer")
 	}
 	*this = append((*this)[0:0], data...)
 	return nil

--- a/tcqueueevents/types.go
+++ b/tcqueueevents/types.go
@@ -7,6 +7,45 @@ import (
 )
 
 type (
+	// Information about the artifact that was created
+	//
+	// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact
+	ArtifactCreated1 struct {
+
+		// Mimetype for the artifact that was created.
+		//
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/contentType
+		ContentType string `json:"contentType"`
+
+		// Date and time after which the artifact created will be automatically
+		// deleted by the queue.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/expires
+		Expires tcclient.Time `json:"expires"`
+
+		// Name of the artifact that was created, this is useful if you want to
+		// attempt to fetch the artifact. But keep in mind that just because an
+		// artifact is created doesn't mean that it's immediately available.
+		//
+		// Max length: 1024
+		//
+		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/name
+		Name string `json:"name"`
+
+		// This is the `storageType` for the request that was used to create the
+		// artifact.
+		//
+		// Possible values:
+		//   * "blob"
+		//   * "reference"
+		//   * "error"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/storageType
+		StorageType string `json:"storageType"`
+	}
+
 	// Message reporting a new artifact has been created for a given task.
 	//
 	// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#
@@ -15,41 +54,7 @@ type (
 		// Information about the artifact that was created
 		//
 		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact
-		Artifact struct {
-
-			// Mimetype for the artifact that was created.
-			//
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/contentType
-			ContentType string `json:"contentType"`
-
-			// Date and time after which the artifact created will be automatically
-			// deleted by the queue.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/expires
-			Expires tcclient.Time `json:"expires"`
-
-			// Name of the artifact that was created, this is useful if you want to
-			// attempt to fetch the artifact. But keep in mind that just because an
-			// artifact is created doesn't mean that it's immediately available.
-			//
-			// Max length: 1024
-			//
-			// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/name
-			Name string `json:"name"`
-
-			// This is the `storageType` for the request that was used to create the
-			// artifact.
-			//
-			// Possible values:
-			//   * "blob"
-			//   * "reference"
-			//   * "error"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/artifact/properties/storageType
-			StorageType string `json:"storageType"`
-		} `json:"artifact"`
+		Artifact ArtifactCreated1 `json:"artifact"`
 
 		// Id of the run on which artifact was created.
 		//
@@ -89,6 +94,117 @@ type (
 		//
 		// See http://schemas.taskcluster.net/queue/v1/artifact-created-message.json#/properties/workerId
 		WorkerID string `json:"workerId"`
+	}
+
+	// JSON object with information about a run
+	//
+	// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items
+	RunInformation struct {
+
+		// Reason for the creation of this run,
+		// **more reasons may be added in the future**.
+		//
+		// Possible values:
+		//   * "scheduled"
+		//   * "retry"
+		//   * "task-retry"
+		//   * "rerun"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
+		ReasonCreated string `json:"reasonCreated"`
+
+		// Reason that run was resolved, this is mainly
+		// useful for runs resolved as `exception`.
+		// Note, **more reasons may be added in the future**, also this
+		// property is only available after the run is resolved. Some of these
+		// reasons, notably `intermittent-task`, `worker-shutdown`, and
+		// `claim-expired`, will trigger an automatic retry of the task.
+		//
+		// Possible values:
+		//   * "completed"
+		//   * "failed"
+		//   * "deadline-exceeded"
+		//   * "canceled"
+		//   * "superseded"
+		//   * "claim-expired"
+		//   * "worker-shutdown"
+		//   * "malformed-payload"
+		//   * "resource-unavailable"
+		//   * "internal-error"
+		//   * "intermittent-task"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
+		ReasonResolved string `json:"reasonResolved,omitempty"`
+
+		// Date-time at which this run was resolved, ie. when the run changed
+		// state from `running` to either `completed`, `failed` or `exception`.
+		// This property is only present after the run as been resolved.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
+		Resolved tcclient.Time `json:"resolved,omitempty"`
+
+		// Id of this task run, `run-id`s always starts from `0`
+		//
+		// Mininum:    0
+		// Maximum:    1000
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
+		RunID int64 `json:"runId"`
+
+		// Date-time at which this run was scheduled, ie. when the run was
+		// created in state `pending`.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
+		Scheduled tcclient.Time `json:"scheduled"`
+
+		// Date-time at which this run was claimed, ie. when the run changed
+		// state from `pending` to `running`. This property is only present
+		// after the run has been claimed.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
+		Started tcclient.Time `json:"started,omitempty"`
+
+		// State of this run
+		//
+		// Possible values:
+		//   * "pending"
+		//   * "running"
+		//   * "completed"
+		//   * "failed"
+		//   * "exception"
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
+		State string `json:"state"`
+
+		// Time at which the run expires and is resolved as `failed`, if the
+		// run isn't reclaimed. Note, only present after the run has been
+		// claimed.
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
+		TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
+
+		// Identifier for group that worker who executes this run is a part of,
+		// this identifier is mainly used for efficient routing.
+		// Note, this property is only present after the run is claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
+		WorkerGroup string `json:"workerGroup,omitempty"`
+
+		// Identifier for worker evaluating this run within given
+		// `workerGroup`. Note, this property is only available after the run
+		// has been claimed.
+		//
+		// Syntax:     ^([a-zA-Z0-9-_]*)$
+		// Min length: 1
+		// Max length: 22
+		//
+		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
+		WorkerID string `json:"workerId,omitempty"`
 	}
 
 	// Message reporting that a task has complete successfully.
@@ -388,113 +504,7 @@ type (
 		// List of runs, ordered so that index `i` has `runId == i`
 		//
 		// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs
-		Runs []struct {
-
-			// Reason for the creation of this run,
-			// **more reasons may be added in the future**.
-			//
-			// Possible values:
-			//   * "scheduled"
-			//   * "retry"
-			//   * "task-retry"
-			//   * "rerun"
-			//   * "exception"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonCreated
-			ReasonCreated string `json:"reasonCreated"`
-
-			// Reason that run was resolved, this is mainly
-			// useful for runs resolved as `exception`.
-			// Note, **more reasons may be added in the future**, also this
-			// property is only available after the run is resolved. Some of these
-			// reasons, notably `intermittent-task`, `worker-shutdown`, and
-			// `claim-expired`, will trigger an automatic retry of the task.
-			//
-			// Possible values:
-			//   * "completed"
-			//   * "failed"
-			//   * "deadline-exceeded"
-			//   * "canceled"
-			//   * "superseded"
-			//   * "claim-expired"
-			//   * "worker-shutdown"
-			//   * "malformed-payload"
-			//   * "resource-unavailable"
-			//   * "internal-error"
-			//   * "intermittent-task"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/reasonResolved
-			ReasonResolved string `json:"reasonResolved,omitempty"`
-
-			// Date-time at which this run was resolved, ie. when the run changed
-			// state from `running` to either `completed`, `failed` or `exception`.
-			// This property is only present after the run as been resolved.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/resolved
-			Resolved tcclient.Time `json:"resolved,omitempty"`
-
-			// Id of this task run, `run-id`s always starts from `0`
-			//
-			// Mininum:    0
-			// Maximum:    1000
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/runId
-			RunID int64 `json:"runId"`
-
-			// Date-time at which this run was scheduled, ie. when the run was
-			// created in state `pending`.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/scheduled
-			Scheduled tcclient.Time `json:"scheduled"`
-
-			// Date-time at which this run was claimed, ie. when the run changed
-			// state from `pending` to `running`. This property is only present
-			// after the run has been claimed.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/started
-			Started tcclient.Time `json:"started,omitempty"`
-
-			// State of this run
-			//
-			// Possible values:
-			//   * "pending"
-			//   * "running"
-			//   * "completed"
-			//   * "failed"
-			//   * "exception"
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/state
-			State string `json:"state"`
-
-			// Time at which the run expires and is resolved as `failed`, if the
-			// run isn't reclaimed. Note, only present after the run has been
-			// claimed.
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/takenUntil
-			TakenUntil tcclient.Time `json:"takenUntil,omitempty"`
-
-			// Identifier for group that worker who executes this run is a part of,
-			// this identifier is mainly used for efficient routing.
-			// Note, this property is only present after the run is claimed.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerGroup
-			WorkerGroup string `json:"workerGroup,omitempty"`
-
-			// Identifier for worker evaluating this run within given
-			// `workerGroup`. Note, this property is only available after the run
-			// has been claimed.
-			//
-			// Syntax:     ^([a-zA-Z0-9-_]*)$
-			// Min length: 1
-			// Max length: 22
-			//
-			// See http://schemas.taskcluster.net/queue/v1/task-status.json#/properties/runs/items/properties/workerId
-			WorkerID string `json:"workerId,omitempty"`
-		} `json:"runs"`
+		Runs []RunInformation `json:"runs"`
 
 		// Identifier for the scheduler that _defined_ this task.
 		//

--- a/tcsecrets/tcsecrets.go
+++ b/tcsecrets/tcsecrets.go
@@ -38,7 +38,7 @@
 //
 // The source code of this go package was auto-generated from the API definition at
 // http://references.taskcluster.net/secrets/v1/api.json together with the input and output schemas it references, downloaded on
-// Mon, 16 Apr 2018 at 13:22:00 UTC. The code was generated
+// Mon, 16 Apr 2018 at 15:01:00 UTC. The code was generated
 // by https://github.com/taskcluster/taskcluster-client-go/blob/master/build.sh.
 package tcsecrets
 

--- a/tctreeherderevents/types.go
+++ b/tctreeherderevents/types.go
@@ -9,6 +9,59 @@ import (
 )
 
 type (
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
+	Display struct {
+
+		// Mininum:    1
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
+		ChunkCount int64 `json:"chunkCount,omitempty"`
+
+		// Mininum:    1
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
+		ChunkID int64 `json:"chunkId,omitempty"`
+
+		// Min length: 1
+		// Max length: 100
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupName
+		GroupName string `json:"groupName,omitempty"`
+
+		// Min length: 1
+		// Max length: 25
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
+		GroupSymbol string `json:"groupSymbol"`
+
+		// Min length: 1
+		// Max length: 100
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobName
+		JobName string `json:"jobName"`
+
+		// Min length: 0
+		// Max length: 25
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
+		JobSymbol string `json:"jobSymbol"`
+	}
+
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items
+	ErrorsEntry struct {
+
+		// Min length: 1
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
+		Line string `json:"line,omitempty"`
+
+		// Mininum:    0
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
+		Linenumber int64 `json:"linenumber,omitempty"`
+	}
+
 	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/origin/oneOf[2]
 	GithubPullRequest struct {
 
@@ -130,42 +183,7 @@ type (
 		Coalesced []string `json:"coalesced,omitempty"`
 
 		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display
-		Display struct {
-
-			// Mininum:    1
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkCount
-			ChunkCount int64 `json:"chunkCount,omitempty"`
-
-			// Mininum:    1
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/chunkId
-			ChunkID int64 `json:"chunkId,omitempty"`
-
-			// Min length: 1
-			// Max length: 100
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupName
-			GroupName string `json:"groupName,omitempty"`
-
-			// Min length: 1
-			// Max length: 25
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/groupSymbol
-			GroupSymbol string `json:"groupSymbol"`
-
-			// Min length: 1
-			// Max length: 100
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobName
-			JobName string `json:"jobName"`
-
-			// Min length: 0
-			// Max length: 25
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/display/properties/jobSymbol
-			JobSymbol string `json:"jobSymbol"`
-		} `json:"display"`
+		Display Display `json:"display"`
 
 		// Extra information that Treeherder reads on a best-effort basis
 		//
@@ -184,35 +202,7 @@ type (
 		// the details panel within Treeherder.
 		//
 		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
-		JobInfo struct {
-
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
-			Links []struct {
-
-				// Min length: 1
-				// Max length: 70
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
-				Label string `json:"label"`
-
-				// Min length: 1
-				// Max length: 125
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
-				LinkText string `json:"linkText"`
-
-				// Max length: 512
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
-				URL string `json:"url"`
-			} `json:"links,omitempty"`
-
-			// Plain text description of the job and its state.  Submitted with
-			// the final message about a task.
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
-			Summary string `json:"summary,omitempty"`
-		} `json:"jobInfo,omitempty"`
+		JobInfo JobInfo `json:"jobInfo,omitempty"`
 
 		// Possible values:
 		//   * "build"
@@ -243,83 +233,7 @@ type (
 		Labels []string `json:"labels,omitempty"`
 
 		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs
-		Logs []struct {
-
-			// If true, indicates that the number of errors in the log was too
-			// large and not all of those lines are indicated here.
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
-			ErrorsTruncated bool `json:"errorsTruncated,omitempty"`
-
-			// Min length: 1
-			// Max length: 50
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
-			Name string `json:"name"`
-
-			// This object defines what is seen in the Treeherder Log Viewer.
-			// These values can be submitted here, or they will be generated
-			// by Treeherder's internal log parsing process from the
-			// submitted log.  If this value is submitted, Treeherder will
-			// consider the log already parsed and skip parsing.
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
-			Steps []struct {
-
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
-				Errors []struct {
-
-					// Min length: 1
-					// Max length: 255
-					//
-					// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/line
-					Line string `json:"line,omitempty"`
-
-					// Mininum:    0
-					//
-					// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors/items/properties/linenumber
-					Linenumber int64 `json:"linenumber,omitempty"`
-				} `json:"errors,omitempty"`
-
-				// Mininum:    0
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
-				LineFinished int64 `json:"lineFinished"`
-
-				// Mininum:    0
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
-				LineStarted int64 `json:"lineStarted"`
-
-				// Min length: 1
-				// Max length: 255
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
-				Name string `json:"name"`
-
-				// Possible values:
-				//   * "success"
-				//   * "fail"
-				//   * "exception"
-				//   * "canceled"
-				//   * "unknown"
-				//
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
-				Result string `json:"result"`
-
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
-				TimeFinished tcclient.Time `json:"timeFinished"`
-
-				// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
-				TimeStarted tcclient.Time `json:"timeStarted"`
-			} `json:"steps,omitempty"`
-
-			// Min length: 1
-			// Max length: 255
-			//
-			// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
-			URL string `json:"url"`
-		} `json:"logs,omitempty"`
+		Logs []LogsEntry `json:"logs,omitempty"`
 
 		// One of:
 		//   * HGPush
@@ -440,6 +354,78 @@ type (
 		Version int64 `json:"version"`
 	}
 
+	// Definition of the Job Info for a job.  These are extra data
+	// fields that go along with a job that will be displayed in
+	// the details panel within Treeherder.
+	//
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo
+	JobInfo struct {
+
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links
+		Links []LinksEntry `json:"links,omitempty"`
+
+		// Plain text description of the job and its state.  Submitted with
+		// the final message about a task.
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/summary
+		Summary string `json:"summary,omitempty"`
+	}
+
+	// List of URLs shown as key/value pairs.  Shown as:
+	// "<label>: <linkText>" where linkText will be a link to the url.
+	//
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items
+	LinksEntry struct {
+
+		// Min length: 1
+		// Max length: 70
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/label
+		Label string `json:"label"`
+
+		// Min length: 1
+		// Max length: 125
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/linkText
+		LinkText string `json:"linkText"`
+
+		// Max length: 512
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/jobInfo/properties/links/items/properties/url
+		URL string `json:"url"`
+	}
+
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items
+	LogsEntry struct {
+
+		// If true, indicates that the number of errors in the log was too
+		// large and not all of those lines are indicated here.
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/errorsTruncated
+		ErrorsTruncated bool `json:"errorsTruncated,omitempty"`
+
+		// Min length: 1
+		// Max length: 50
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/name
+		Name string `json:"name"`
+
+		// This object defines what is seen in the Treeherder Log Viewer.
+		// These values can be submitted here, or they will be generated
+		// by Treeherder's internal log parsing process from the
+		// submitted log.  If this value is submitted, Treeherder will
+		// consider the log already parsed and skip parsing.
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps
+		Steps []StepsEntry `json:"steps,omitempty"`
+
+		// Min length: 1
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/url
+		URL string `json:"url"`
+	}
+
 	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine
 	Machine struct {
 
@@ -470,5 +456,44 @@ type (
 		//
 		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/definitions/machine/properties/platform
 		Platform string `json:"platform"`
+	}
+
+	// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items
+	StepsEntry struct {
+
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/errors
+		Errors []ErrorsEntry `json:"errors,omitempty"`
+
+		// Mininum:    0
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineFinished
+		LineFinished int64 `json:"lineFinished"`
+
+		// Mininum:    0
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/lineStarted
+		LineStarted int64 `json:"lineStarted"`
+
+		// Min length: 1
+		// Max length: 255
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/name
+		Name string `json:"name"`
+
+		// Possible values:
+		//   * "success"
+		//   * "fail"
+		//   * "exception"
+		//   * "canceled"
+		//   * "unknown"
+		//
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/result
+		Result string `json:"result"`
+
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeFinished
+		TimeFinished tcclient.Time `json:"timeFinished"`
+
+		// See http://schemas.taskcluster.net/taskcluster-treeherder/v1/pulse-job.json#/properties/logs/items/properties/steps/items/properties/timeStarted
+		TimeStarted tcclient.Time `json:"timeStarted"`
 	}
 )


### PR DESCRIPTION
Note - you only need to review [the first commit](https://github.com/taskcluster/taskcluster-client-go/pull/32/commits/c0bf6c9fb84e14b852274524da3ddf89b22ee718), not the second (generated) one!

Note, due to the large amount of duplication we have in our schemas, we have a number of duplicate types, e.g.:

https://github.com/taskcluster/taskcluster-queue/blob/a8908c3dbec6c8668bc8c2afce56c98b0d701d77/schemas/list-provisioners-response.yml#L44-L87
https://github.com/taskcluster/taskcluster-queue/blob/a8908c3dbec6c8668bc8c2afce56c98b0d701d77/schemas/provisioner-response.yml#L42-L85
https://github.com/taskcluster/taskcluster-queue/blob/a8908c3dbec6c8668bc8c2afce56c98b0d701d77/schemas/update-provisioner-request.yml#L28-L63
https://github.com/taskcluster/taskcluster-queue/blob/a8908c3dbec6c8668bc8c2afce56c98b0d701d77/schemas/workertype-response.yml#L50-L93
https://github.com/taskcluster/taskcluster-queue/blob/a8908c3dbec6c8668bc8c2afce56c98b0d701d77/schemas/worker-response.yml#L85-L128

I intend to follow up with a round of schema updates to remove the duplication (i.e. using `$ref` to point to a single definition). I prefer doing that to trying to check for struct identity, since struct identity may be by coincidence rather than intent, and if one schema is adjusted, i don't want it to suddenly split into two types where it was one type before, and break code.