### PR TITLE
Bug 1484702 - add unit tests, and fix the implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.8
+  - 1.9
 
 before_install:
   - go version

--- a/http.go
+++ b/http.go
@@ -84,9 +84,11 @@ var defaultHTTPClient ReducedHTTPClient = &http.Client{}
 // utility function to create a URL object based on given data
 func setURL(client *Client, route string, query url.Values) (u *url.URL, err error) {
 	URL := client.BaseURL
-	// avoid double separator...
-	if !strings.HasSuffix(URL, "/") {
-		URL += "/"
+	// See https://bugzil.la/1484702
+	// Avoid double separator; routes must start with `/`, so baseURL shouldn't
+	// end with `/`.
+	if strings.HasSuffix(URL, "/") {
+		URL = URL[:len(URL)-1]
 	}
 	URL += route
 	u, err = url.Parse(URL)


### PR DESCRIPTION
See [bug 1484702](https://bugzil.la/1484702). The previous implementation (#34) broke fresh builds of `taskcluster-proxy`. This time I've added unit tests, and corrected the implementation.