### PR TITLE
Bug 1502075 - stop using v1 treeherder routes in integration tests

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -78,7 +78,7 @@ go tool cover -func=coverage.report
 # See https://bugzilla.mozilla.org/show_bug.cgi?id=1221239
 grep -q PANIC codegenerator/model-data.txt && exit 68
 
-go get github.com/golang/lint/golint
+go get golang.org/x/lint/golint
 "${GOPATH}/bin/golint" codegenerator/...; "${GOPATH}/bin/golint" integrationtest/...; "${GOPATH}/bin/golint" .
 
 go get github.com/gordonklaus/ineffassign

--- a/integrationtest/integration_test.go
+++ b/integrationtest/integration_test.go
@@ -93,8 +93,7 @@ func TestDefineTask(t *testing.T) {
 		ProvisionerID: "win-provisioner",
 		Retries:       5,
 		Routes: []string{
-			"tc-treeherder.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163",
-			"tc-treeherder-stage.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163",
+			"garbage.tc-client-go.test",
 		},
 		SchedulerID: "go-test-test-scheduler",
 		Scopes: []string{
@@ -157,8 +156,7 @@ func TestDefineTask(t *testing.T) {
 	  "retries":       5,
 
 	  "routes": [
-	    "tc-treeherder.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163",
-	    "tc-treeherder-stage.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163"
+	    "garbage.tc-client-go.test"
 	  ],
 
 	  "scopes": [


### PR DESCRIPTION
Note, the commit hash is invented.

See [bug 1502075](https://bugzil.la/1502075) for context.